### PR TITLE
Refine dark theme contrast and capture subreddit eligibility

### DIFF
--- a/components/ErrorBoundary.tsx
+++ b/components/ErrorBoundary.tsx
@@ -73,7 +73,7 @@ class ErrorBoundary extends Component<Props, State> {
 
       // Default mobile-friendly error UI
       return (
-        <div className="min-h-screen bg-background flex items-center justify-center p-4">
+        <div className="min-h-viewport bg-background flex items-center justify-center p-4">
           <div className="max-w-md w-full space-y-6 text-center">
             {/* Error Icon */}
             <div className="flex justify-center">

--- a/components/MediaUpload.tsx
+++ b/components/MediaUpload.tsx
@@ -7,9 +7,10 @@ interface Props {
   onUrl: (url: string) => void;
   onFile: (files: File[]) => void;
   mode: 'file' | 'url';
+  resetSignal?: number;
 }
 
-export default function MediaUpload({ onUrl, onFile, mode }: Props) {
+export default function MediaUpload({ onUrl, onFile, mode, resetSignal }: Props) {
   const [mediaUrl, setMediaUrl] = React.useState('');
   const [selectedFiles, setSelectedFiles] = React.useState<File[]>([]);
   const [previewUrls, setPreviewUrls] = React.useState<string[]>([]);
@@ -85,20 +86,25 @@ export default function MediaUpload({ onUrl, onFile, mode }: Props) {
     onFile(newFiles);
   };
 
-  const clearMedia = () => {
+  const clearMedia = React.useCallback(() => {
     setSelectedFiles([]);
     setMediaUrl('');
     onFile([]);
     onUrl('');
     previewUrls.forEach(url => URL.revokeObjectURL(url));
     setPreviewUrls([]);
-  };
+  }, [onFile, onUrl, previewUrls]);
 
   React.useEffect(() => {
     return () => {
       previewUrls.forEach(url => URL.revokeObjectURL(url));
     };
   }, [previewUrls]);
+
+  React.useEffect(() => {
+    if (resetSignal === undefined) return;
+    clearMedia();
+  }, [resetSignal, clearMedia]);
 
   return (
     <div>

--- a/components/MediaUpload.tsx
+++ b/components/MediaUpload.tsx
@@ -15,6 +15,9 @@ export default function MediaUpload({ onUrl, onFile, mode, resetSignal }: Props)
   const [selectedFiles, setSelectedFiles] = React.useState<File[]>([]);
   const [previewUrls, setPreviewUrls] = React.useState<string[]>([]);
   const [rejectionError, setRejectionError] = React.useState<string | null>(null);
+  const previewUrlsRef = React.useRef<string[]>([]);
+  const onFileRef = React.useRef(onFile);
+  const onUrlRef = React.useRef(onUrl);
 
   const handleDropRejected = React.useCallback((fileRejections: FileRejection[]) => {
     const errors: string[] = [];
@@ -89,11 +92,20 @@ export default function MediaUpload({ onUrl, onFile, mode, resetSignal }: Props)
   const clearMedia = React.useCallback(() => {
     setSelectedFiles([]);
     setMediaUrl('');
-    onFile([]);
-    onUrl('');
-    previewUrls.forEach(url => URL.revokeObjectURL(url));
+    onFileRef.current([]);
+    onUrlRef.current('');
+    previewUrlsRef.current.forEach(url => URL.revokeObjectURL(url));
     setPreviewUrls([]);
-  }, [onFile, onUrl, previewUrls]);
+  }, []);
+
+  React.useEffect(() => {
+    previewUrlsRef.current = previewUrls;
+  }, [previewUrls]);
+
+  React.useEffect(() => {
+    onFileRef.current = onFile;
+    onUrlRef.current = onUrl;
+  }, [onFile, onUrl]);
 
   React.useEffect(() => {
     return () => {
@@ -104,7 +116,7 @@ export default function MediaUpload({ onUrl, onFile, mode, resetSignal }: Props)
   React.useEffect(() => {
     if (resetSignal === undefined) return;
     clearMedia();
-  }, [resetSignal, clearMedia]);
+  }, [resetSignal]);
 
   return (
     <div>

--- a/components/PostComposer.tsx
+++ b/components/PostComposer.tsx
@@ -50,7 +50,7 @@ export default function PostComposer({ value, onChange, body, onBodyChange, pref
   };
 
   return (
-    <div className="space-y-3">
+    <div className="space-y-1">
       {/* Title Input */}
       <div>
         <Textarea
@@ -73,7 +73,7 @@ export default function PostComposer({ value, onChange, body, onBodyChange, pref
         <button
           type="button"
           onClick={() => setShowBody(!showBody)}
-          className="flex items-center gap-1 text-sm text-muted-foreground hover:text-foreground transition-colors"
+          className="flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
         >
           {showBody ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
           <span>Add description{body && body.length > 0 ? ` (${body.length} chars)` : ''}</span>

--- a/components/PostingQueue.tsx
+++ b/components/PostingQueue.tsx
@@ -45,6 +45,7 @@ interface Props {
   onPostAttempt?: () => boolean;
   onUnselectSuccessItems?: (subreddits: string[]) => void;
   onClearAll?: () => void;
+  onResetMedia?: () => void;
   /** Max items allowed (e.g. 5 for paid). Falls back to QUEUE_LIMITS.MAX_TOTAL_ITEMS */
   maxItems?: number;
   /** Callback when posting results are available (for failed post tracking) */
@@ -161,6 +162,7 @@ const PostingQueue: React.FC<Props> = ({
   onPostAttempt,
   onUnselectSuccessItems,
   onClearAll,
+  onResetMedia,
   maxItems: maxItemsProp,
   onResultsAvailable,
   onValidationChange,
@@ -587,6 +589,13 @@ const PostingQueue: React.FC<Props> = ({
     });
   };
 
+  const handleMobileReset = useCallback(() => {
+    reset();
+    if (onResetMedia) {
+      onResetMedia();
+    }
+  }, [reset, onResetMedia]);
+
   // Get the appropriate error icon based on error type
   const getErrorIcon = () => {
     if (error?.message?.includes('network') || error?.message?.includes('connect')) {
@@ -868,7 +877,7 @@ const PostingQueue: React.FC<Props> = ({
         isCompleted={completed}
         hasErrors={hasFlairErrors || !batchInfo.canProceed || !validation.canSubmit}
         onPostClick={handleButtonClick}
-        onResetClick={reset}
+        onResetClick={handleMobileReset}
         onStopClick={handleCancel}
         onClearClick={onClearAll}
       />

--- a/components/PostingQueue.tsx
+++ b/components/PostingQueue.tsx
@@ -474,6 +474,17 @@ const PostingQueue: React.FC<Props> = ({
   const cancelled = state.status === 'cancelled';
   const failed = state.status === 'failed';
 
+  // Auto-scroll and focus queue when posting starts
+  const queueRef = React.useRef<HTMLDivElement | null>(null);
+  const prevRunningRef = React.useRef<boolean>(false);
+  useEffect(() => {
+    if (!prevRunningRef.current && running) {
+      queueRef.current?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+      queueRef.current?.focus({ preventScroll: true });
+    }
+    prevRunningRef.current = running;
+  }, [running]);
+
   // Notify parent when results are available (for failed post tracking)
   const prevStatusRef = React.useRef<string | null>(null);
   React.useEffect(() => {
@@ -614,15 +625,22 @@ const PostingQueue: React.FC<Props> = ({
   const isRecoverable = error?.recoverable !== false;
 
   return (
-    <div className="space-y-4">
+    <div className="space-y-4" ref={queueRef} tabIndex={-1}>
       {/* Posting Queue Header - Visible when posting starts */}
       {(running || logs.length > 0) && (
-        <div className="flex items-center gap-2 mb-2">
-          <h3 className="text-lg font-semibold">Ready to post</h3>
-          {items.length > 0 && (
-            <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-primary/20 text-primary">
-              {items.length}
-            </span>
+        <div className="flex flex-col gap-2 mb-2">
+          <div className="flex items-center gap-2">
+            <h3 className="text-base lg:text-lg font-semibold tracking-tight">Ready to post</h3>
+            {items.length > 0 && (
+              <span className="px-2 py-0.5 rounded-full text-xs font-medium bg-primary/20 text-primary">
+                {items.length}
+              </span>
+            )}
+          </div>
+          {running && (
+            <p className="text-xs sm:text-sm text-muted-foreground">
+              Posting can take a few minutes. Please keep this tab open and wait.
+            </p>
           )}
         </div>
       )}
@@ -868,7 +886,7 @@ const PostingQueue: React.FC<Props> = ({
       )}
 
       {/* Spacer for Mobile Sticky Queue */}
-      <div className="min-h-[calc(2rem+env(safe-area-inset-bottom,0px))] lg:min-h-0 lg:h-0" aria-hidden="true" />
+      {/* <div className="min-h-[calc(2rem+env(safe-area-inset-bottom,0px))] lg:min-h-0 lg:h-0" aria-hidden="true" /> */}
 
       {/* Mobile Sticky Queue Footer */}
       <MobileStickyQueue

--- a/components/PwaOnboarding.tsx
+++ b/components/PwaOnboarding.tsx
@@ -510,7 +510,7 @@ export const PwaOnboarding: React.FC<PwaOnboardingProps> = ({ hasQueueItems = fa
           role="region"
           aria-label="Add to home screen"
         >
-          <div className="container mx-auto flex items-center justify-between px-4 py-2.5">
+          <div className="app-container flex items-center justify-between py-2.5">
             <div className="flex items-center gap-3">
               <div className="relative">
                 <div className="w-9 h-9 rounded-xl bg-gradient-to-br from-primary to-orange-600 flex items-center justify-center shadow-sm animate-pwa-icon-pulse">

--- a/components/SubredditFlairPicker.tsx
+++ b/components/SubredditFlairPicker.tsx
@@ -360,7 +360,7 @@ const SubredditFlairPicker: React.FC<Props> = ({
               <div className="text-xs font-semibold text-muted-foreground uppercase tracking-wider px-2 py-1.5">
                 Your communities
               </div>
-              <div className="rounded-md border border-border overflow-hidden">
+              <div className="space-y-2">
                 {localFilteredSubreddits.map((name) => {
                   const hasError = !!(showValidationErrors && hasMissingFlair(name));
                   const failedPost = failedPostsBySubreddit[name.toLowerCase()];

--- a/components/UpgradeModal.tsx
+++ b/components/UpgradeModal.tsx
@@ -48,7 +48,8 @@ const UpgradeModal: React.FC<UpgradeModalProps> = ({
 
   const benefits = [
     'Unlimited communities',
-    'Post to as many as you want at once',
+    'Post to as many communities as you want at once',
+    'Custom title & description for each community',
     'No limits',
     'Pay once',
   ];

--- a/components/layout/AppFooter.tsx
+++ b/components/layout/AppFooter.tsx
@@ -1,25 +1,58 @@
 'use client';
 
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useRef } from 'react';
 import Link from 'next/link';
 import { cn } from '@/lib/utils';
 
 const VERBS = ['hacked', 'built', 'crafted', 'made', 'designed', 'coded', 'created', 'forged'];
 const MORPH_INTERVAL = 3000; // 3 seconds between morphs
+const GLITCH_DURATION = 700;
+const GLITCH_TICK = 45;
+const GLITCH_CHARS = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789#$%&*+-?';
 
 export const AppFooter: React.FC = () => {
   const [currentVerbIndex, setCurrentVerbIndex] = useState(0);
+  const [displayVerb, setDisplayVerb] = useState(VERBS[0]);
   const [isAnimating, setIsAnimating] = useState(false);
+  const currentVerbRef = useRef(0);
+  const isAnimatingRef = useRef(false);
 
   useEffect(() => {
-    const interval = setInterval(() => {
+    currentVerbRef.current = currentVerbIndex;
+  }, [currentVerbIndex]);
+
+  useEffect(() => {
+    const startGlitch = (toIndex: number) => {
+      if (isAnimatingRef.current) return;
+      isAnimatingRef.current = true;
       setIsAnimating(true);
-      
-      // After fade out completes, change the word
-      setTimeout(() => {
-        setCurrentVerbIndex((prev) => (prev + 1) % VERBS.length);
-        setIsAnimating(false);
-      }, 300);
+
+      const target = VERBS[toIndex];
+      const start = Date.now();
+
+      const tick = setInterval(() => {
+        const progress = Math.min((Date.now() - start) / GLITCH_DURATION, 1);
+        const revealCount = Math.floor(progress * target.length);
+        const scrambled = target
+          .split('')
+          .map((char, index) => (index < revealCount ? char : GLITCH_CHARS[Math.floor(Math.random() * GLITCH_CHARS.length)]))
+          .join('');
+
+        setDisplayVerb(scrambled);
+
+        if (progress >= 1) {
+          clearInterval(tick);
+          setDisplayVerb(target);
+          setIsAnimating(false);
+          isAnimatingRef.current = false;
+          setCurrentVerbIndex(toIndex);
+        }
+      }, GLITCH_TICK);
+    };
+
+    const interval = setInterval(() => {
+      const nextIndex = (currentVerbRef.current + 1) % VERBS.length;
+      startGlitch(nextIndex);
     }, MORPH_INTERVAL);
 
     return () => clearInterval(interval);
@@ -27,21 +60,11 @@ export const AppFooter: React.FC = () => {
 
   return (
     <footer className="relative mt-auto">
-      {/* Clean separator line */}
-      <div className="h-px bg-border/50" />
-      
-      {/* Footer content with noise texture */}
-      <div 
-        className={cn(
-          "noise-texture noise-subtle",
-          "relative overflow-hidden",
-          "px-4 sm:px-6 py-2 sm:py-4",
-          "bg-muted/30"
-        )}
-      >
-        <div className="relative max-w-7xl mx-auto flex items-center justify-between">
+      <div className="h-px bg-border/60" />
+      <div className="relative overflow-hidden app-container py-3 sm:py-4">
+        <div className="relative flex flex-col sm:flex-row items-start sm:items-center justify-between gap-2 sm:gap-6">
           {/* Left side - Privacy / Terms */}
-          <div className="flex items-center gap-1.5 text-xs sm:text-sm text-muted-foreground">
+          <div className="flex items-center gap-1.5 text-[11px] sm:text-xs text-muted-foreground">
             <Link 
               href="/privacy" 
               className="hover:text-foreground transition-colors duration-200 cursor-pointer"
@@ -61,15 +84,15 @@ export const AppFooter: React.FC = () => {
           <div className="flex items-center gap-1.5 text-xs sm:text-sm text-muted-foreground">
             <span
               className={cn(
-                'inline-block min-w-[52px] text-right font-mono italic',
-                'text-primary/80',
-                'transition-all duration-300 ease-out',
+                'inline-block min-w-[60px] text-right font-mono italic tracking-wider',
+                'text-orange-600',
+                'transition-all duration-200 ease-out',
                 isAnimating 
-                  ? 'opacity-0 translate-y-1 blur-[2px]' 
-                  : 'opacity-100 translate-y-0 blur-0'
+                  ? 'opacity-70 blur-[1px]' 
+                  : 'opacity-100 blur-0'
               )}
             >
-              {VERBS[currentVerbIndex]}
+              {displayVerb}
             </span>
             <span className="text-muted-foreground">by</span>
             <span className="text-muted-foreground/80 tracking-wide">

--- a/components/layout/AppHeader.tsx
+++ b/components/layout/AppHeader.tsx
@@ -1,11 +1,10 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { Avatar } from '@/components/ui/avatar';
 import { DropdownMenu, DropdownMenuItem, DropdownMenuSeparator } from '@/components/ui/dropdown-menu';
-import { ChevronDown, User, Settings, LogOut, Shield, Sun, Moon, Monitor, Infinity, TrendingUp, Clock, Users } from 'lucide-react';
+import { ChevronDown, User, Settings, LogOut, Shield, Sun, Moon, Monitor, Infinity } from 'lucide-react';
 import { useTheme } from '@/contexts/ThemeContext';
 import type { Theme } from '@/contexts/ThemeContext';
 import { cn } from '@/lib/utils';
-import { Tooltip } from '@/components/ui/tooltip';
 
 interface UserStats {
   totalKarma?: number;
@@ -25,29 +24,6 @@ interface AppHeaderProps {
   upgradeLoading?: boolean;
   userStats?: UserStats;
 }
-
-/**
- * Get eligibility status based on user stats
- */
-const getEligibilityStatus = (stats: UserStats): 'good' | 'warning' | 'error' => {
-  const karma = stats.totalKarma ?? 0;
-  const accountAge = stats.accountAgeDays ?? 0;
-  const emailVerified = stats.hasVerifiedEmail ?? false;
-  
-  const issues: string[] = [];
-  
-  if (karma < 10) issues.push('very low karma');
-  else if (karma < 100) issues.push('low karma');
-  
-  if (accountAge < 3) issues.push('very new account');
-  else if (accountAge < 7) issues.push('new account');
-  
-  if (!emailVerified) issues.push('email not verified');
-  
-  if (issues.length >= 2 || karma < 10 || accountAge < 3) return 'error';
-  if (issues.length >= 1) return 'warning';
-  return 'good';
-};
 
 /**
  * Custom hook for mobile scroll-aware header behavior
@@ -113,7 +89,7 @@ const AppHeader: React.FC<AppHeaderProps> = ({
   entitlement,
   onUpgrade,
   upgradeLoading = false,
-  userStats,
+  userStats: _userStats,
 }) => {
   const { theme, setTheme } = useTheme();
   const { isVisible, isAtTop } = useScrollDirection();
@@ -130,19 +106,6 @@ const AppHeader: React.FC<AppHeaderProps> = ({
     setTheme(next);
   };
   
-  // Calculate eligibility status for the status orb
-  const eligibilityStatus = userStats ? getEligibilityStatus(userStats) : 'good';
-  const statusColors = {
-    good: 'bg-emerald-500',
-    warning: 'bg-amber-500',
-    error: 'bg-red-500',
-  };
-  const statusLabels = {
-    good: 'Ready to post',
-    warning: 'Some restrictions may apply',
-    error: 'Posting may be restricted',
-  };
-
   const handleThemeSelect = (next: Theme) => () => setTheme(next);
 
   const handleViewProfile = () => {
@@ -173,10 +136,10 @@ const AppHeader: React.FC<AppHeaderProps> = ({
         !isVisible && "-translate-y-full"
       )}
     >
-      <div className="container mx-auto px-3 sm:px-4">
-        <div className="grid h-14 min-h-[44px] grid-cols-[1fr_auto_1fr] items-center gap-2">
+      <div className="app-container">
+        <div className="flex h-14 min-h-[44px] items-center gap-2">
           {/* Logo */}
-          <div className="flex min-w-0 shrink-0 items-center gap-2.5 justify-self-start">
+          <div className="flex min-w-0 shrink-0 items-center gap-2.5">
             <div className="relative h-9 w-9 shrink-0 overflow-hidden rounded-lg flex items-center justify-center">
               <img 
                 src="/logo.png" 
@@ -196,51 +159,34 @@ const AppHeader: React.FC<AppHeaderProps> = ({
             )}
           </div>
 
-          {/* Desktop: User Stats - Karma & Account Age */}
-          {userStats && (
-            <Tooltip
-              content={
-                <div className="text-xs space-y-1 p-1">
-                  <p className="font-medium">{statusLabels[eligibilityStatus]}</p>
-                  <p>Karma: {(userStats.totalKarma ?? 0).toLocaleString()}</p>
-                  <p>Followers: {(userStats.followers ?? 0).toLocaleString()}</p>
-                  <p>Account: {userStats.accountAgeLabel || 'Unknown'} old</p>
-                  <p>Email: {userStats.hasVerifiedEmail ? 'Verified' : 'Not verified'}</p>
-                </div>
-              }
-              side="bottom"
-            >
-              <div className="hidden md:flex items-center gap-2 px-3 py-1.5 rounded-md bg-secondary/50 border border-border/50 cursor-help transition-colors hover:bg-secondary justify-self-center">
-                {/* Status orb */}
-                <div className={cn(
-                  "w-2 h-2 rounded-full shrink-0",
-                  statusColors[eligibilityStatus],
-                  eligibilityStatus === 'good' && "animate-eligibility-pulse",
-                  eligibilityStatus === 'warning' && "animate-eligibility-pulse-warning",
-                  eligibilityStatus === 'error' && "animate-eligibility-pulse-blocked"
-                )} />
-                {/* Karma */}
-                <div className="flex items-center gap-1 text-sm">
-                  <TrendingUp className="w-3.5 h-3.5 text-muted-foreground" />
-                  <span className="font-medium">{(userStats.totalKarma ?? 0).toLocaleString()}</span>
-                </div>
-                <span className="text-muted-foreground/40">·</span>
-                {/* Followers */}
-                <div className="flex items-center gap-1 text-sm">
-                  <Users className="w-3.5 h-3.5 text-muted-foreground" />
-                  <span className="font-medium">{(userStats.followers ?? 0).toLocaleString()}</span>
-                </div>
-                <span className="text-muted-foreground/40">·</span>
-                {/* Account Age */}
-                <div className="flex items-center gap-1 text-sm">
-                  <Clock className="w-3.5 h-3.5 text-muted-foreground" />
-                  <span className="font-medium">{userStats.accountAgeLabel || 'Unknown'}</span>
-                </div>
-              </div>
-            </Tooltip>
-          )}
+          {/* Desktop: User Stats removed (now shown in sub-header banner) */}
 
-          <div className="flex min-w-0 shrink items-center gap-2 sm:gap-3 justify-self-end">
+          <div className="flex min-w-0 shrink items-center gap-2 sm:gap-3 ml-auto">
+            
+
+            {showUpgrade && (
+              <button
+                type="button"
+                onClick={onUpgrade}
+                disabled={upgradeLoading}
+                className={cn(
+                  "shrink-0 flex items-center gap-1.5 text-xs sm:text-sm cursor-pointer",
+                  "disabled:opacity-50 disabled:cursor-not-allowed",
+                  "rounded-md px-3.5 py-1.5 font-semibold",
+                  "text-white border border-violet-700/40",
+                  "bg-violet-800/90",
+                  "transition-all duration-200",
+                  "hover:bg-violet-800",
+                  "animate-subtle-glow",
+                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
+                )}
+                aria-label="Go Unlimited"
+              >
+                <Infinity className="h-4 w-4" aria-hidden="true" />
+                <span className="hidden sm:inline">{upgradeLoading ? 'Opening checkout…' : 'Go Unlimited'}</span>
+                <span className="sm:hidden">{upgradeLoading ? '…' : 'Go Unlimited'}</span>
+              </button>
+            )}
             {/* Mobile-only: Theme cycle button */}
             <button
               type="button"
@@ -254,28 +200,6 @@ const AppHeader: React.FC<AppHeaderProps> = ({
             >
               <ThemeIcon className="w-[18px] h-[18px] text-muted-foreground" aria-hidden="true" />
             </button>
-
-            {showUpgrade && (
-              <button
-                type="button"
-                onClick={onUpgrade}
-                disabled={upgradeLoading}
-                className={cn(
-                  "shrink-0 flex items-center gap-1.5 text-xs sm:text-sm cursor-pointer",
-                  "disabled:opacity-50 disabled:cursor-not-allowed",
-                  "rounded-md px-3 py-2 font-semibold",
-                  "bg-violet-600 text-white",
-                  "transition-colors duration-200",
-                  "hover:bg-violet-500",
-                  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 focus-visible:ring-offset-2 focus-visible:ring-offset-background"
-                )}
-                aria-label="Go Unlimited"
-              >
-                <Infinity className="h-4 w-4" aria-hidden="true" />
-                <span className="hidden sm:inline">{upgradeLoading ? 'Opening checkout…' : 'Go Unlimited'}</span>
-                <span className="sm:hidden">{upgradeLoading ? '…' : 'Go Unlimited'}</span>
-              </button>
-            )}
             {/* Desktop-only: User dropdown (profile/settings/theme/logout moved to bottom nav on mobile) */}
             <div className="hidden md:flex">
             <DropdownMenu

--- a/components/layout/AppHeader.tsx
+++ b/components/layout/AppHeader.tsx
@@ -248,7 +248,6 @@ const AppHeader: React.FC<AppHeaderProps> = ({
               className={cn(
                 "md:hidden min-h-[44px] min-w-[44px]",
                 "flex items-center justify-center",
-                "rounded-md hover:bg-secondary transition-colors",
                 "cursor-pointer active:scale-95"
               )}
               aria-label={`Theme: ${theme}. Tap to switch.`}

--- a/components/layout/MobileBottomNav.tsx
+++ b/components/layout/MobileBottomNav.tsx
@@ -126,15 +126,12 @@ const MobileBottomNav: React.FC = () => {
   const isActive = (tab: NavTab): boolean =>
     tab.matchPaths.includes(router.pathname);
 
-  const activeIndex = visibleTabs.findIndex((tab) => isActive(tab));
-  const indicatorWidth = visibleTabs.length > 0 ? 100 / visibleTabs.length : 0;
-
   return (
     <>
       {/* Bottom navigation bar */}
       <nav
         className={cn(
-          "fixed bottom-0 left-0 right-0 z-50 md:hidden",
+          "fixed bottom-0 left-0 right-0 z-50 md:hidden mobile-bottom-nav",
           "bg-background/95 backdrop-blur-sm",
           "border-t border-border/50",
           "pb-[env(safe-area-inset-bottom)]"
@@ -142,18 +139,7 @@ const MobileBottomNav: React.FC = () => {
         role="navigation"
         aria-label="Main navigation"
       >
-        <div className="relative flex items-stretch justify-around h-14">
-          <div
-            className={cn(
-              "absolute bottom-0 h-0.5 bg-primary transition-transform duration-200 ease-out",
-              activeIndex === -1 && "opacity-0"
-            )}
-            style={{
-              width: `${indicatorWidth}%`,
-              transform: `translateX(${activeIndex * 100}%)`,
-            }}
-            aria-hidden="true"
-          />
+        <div className="flex items-stretch justify-around h-14">
           {visibleTabs.map((tab) => {
             const active = isActive(tab);
             return (

--- a/components/layout/MobileBottomNav.tsx
+++ b/components/layout/MobileBottomNav.tsx
@@ -126,6 +126,9 @@ const MobileBottomNav: React.FC = () => {
   const isActive = (tab: NavTab): boolean =>
     tab.matchPaths.includes(router.pathname);
 
+  const activeIndex = visibleTabs.findIndex((tab) => isActive(tab));
+  const indicatorWidth = visibleTabs.length > 0 ? 100 / visibleTabs.length : 0;
+
   return (
     <>
       {/* Bottom navigation bar */}
@@ -139,7 +142,18 @@ const MobileBottomNav: React.FC = () => {
         role="navigation"
         aria-label="Main navigation"
       >
-        <div className="flex items-stretch justify-around h-14">
+        <div className="relative flex items-stretch justify-around h-14">
+          <div
+            className={cn(
+              "absolute bottom-0 h-0.5 bg-primary transition-transform duration-200 ease-out",
+              activeIndex === -1 && "opacity-0"
+            )}
+            style={{
+              width: `${indicatorWidth}%`,
+              transform: `translateX(${activeIndex * 100}%)`,
+            }}
+            aria-hidden="true"
+          />
           {visibleTabs.map((tab) => {
             const active = isActive(tab);
             return (
@@ -179,14 +193,14 @@ const MobileBottomNav: React.FC = () => {
         <>
           {/* Backdrop */}
           <div
-            className="fixed inset-0 z-[60] bg-black/40 backdrop-blur-[2px] md:hidden animate-in fade-in duration-200"
+            className="fixed inset-0 z-[110] bg-black/40 backdrop-blur-[2px] md:hidden animate-in fade-in duration-200"
             onClick={() => setProfileOpen(false)}
             aria-hidden="true"
           />
           {/* Sheet */}
           <div
             className={cn(
-              "fixed bottom-0 left-0 right-0 z-[70] md:hidden",
+              "fixed bottom-0 left-0 right-0 z-[120] md:hidden",
               "bg-background rounded-t-2xl",
               "border-t border-border/50",
               "pb-[env(safe-area-inset-bottom)]",

--- a/components/layout/MobileUserStatsBanner.tsx
+++ b/components/layout/MobileUserStatsBanner.tsx
@@ -1,7 +1,6 @@
 import React, { useState, useEffect, useRef } from 'react';
 import { cn } from '@/lib/utils';
 import { TrendingUp, Clock, Users } from 'lucide-react';
-import { Tooltip } from '@/components/ui/tooltip';
 
 interface UserStats {
   totalKarma?: number;
@@ -54,9 +53,9 @@ const useMobileStatsVisibility = () => {
     const updateVisibility = () => {
       const scrollY = window.scrollY;
       
-      // Only apply on mobile
+      // Only apply scroll-hide on mobile
       if (window.innerWidth >= 768) {
-        setIsVisible(false); // Always hidden on desktop
+        setIsVisible(true); // Always visible on desktop/tablet
         ticking.current = false;
         return;
       }
@@ -83,7 +82,7 @@ const useMobileStatsVisibility = () => {
     // Also handle resize
     const handleResize = () => {
       if (window.innerWidth >= 768) {
-        setIsVisible(false);
+        setIsVisible(true);
       } else if (window.scrollY < 50) {
         setIsVisible(true);
       }
@@ -127,77 +126,66 @@ export const MobileUserStatsBanner: React.FC<MobileUserStatsBannerProps> = ({
   return (
     <div
       className={cn(
-        // Only show on mobile
-        "md:hidden",
+        // Show on all sizes (mobile scroll-hides, desktop stays visible)
         // Positioning
         "sticky top-14 z-40",
         // Visual styling
         "bg-background/90 backdrop-blur-md",
         "border-b border-border/50",
         // Padding
-        "px-4 py-2",
+        "py-1 md:py-1.5",
         // Transition for smooth hide/show
         "transition-all duration-300 ease-out",
+        "bg-neutral-100 dark:bg-neutral-900",
         // Hide state
         !isVisible && "opacity-0 -translate-y-full pointer-events-none h-0 py-0 border-0 overflow-hidden",
         isVisible && "opacity-100 translate-y-0",
         className
       )}
     >
-      <Tooltip
-        content={
-          <div className="text-xs space-y-1 p-1">
-            <p className="font-medium">{statusLabels[eligibilityStatus]}</p>
-            <p>Karma: {(userStats.totalKarma ?? 0).toLocaleString()}</p>
-            <p>Followers: {(userStats.followers ?? 0).toLocaleString()}</p>
-            <p>Account: {userStats.accountAgeLabel || 'Unknown'} old</p>
-            <p>Email: {userStats.hasVerifiedEmail ? 'Verified' : 'Not verified'}</p>
-          </div>
-        }
-        side="bottom"
-      >
-        <div className="flex items-center justify-center gap-3 cursor-help">
-          {/* Status orb */}
-          <div className={cn(
-            "w-2 h-2 rounded-full shrink-0",
-            statusColors[eligibilityStatus],
-            eligibilityStatus === 'good' && "animate-eligibility-pulse",
-            eligibilityStatus === 'warning' && "animate-eligibility-pulse-warning",
-            eligibilityStatus === 'error' && "animate-eligibility-pulse-blocked"
-          )} />
-          
-          {/* Karma */}
-          <div className="flex items-center gap-1.5 text-sm">
-            <TrendingUp className="w-3.5 h-3.5 text-muted-foreground" />
-            <span className="font-semibold">{(userStats.totalKarma ?? 0).toLocaleString()}</span>
-            <span className="text-muted-foreground text-xs">karma</span>
-          </div>
-          
-          <span className="text-muted-foreground/40">·</span>
-          
-          {/* Followers */}
-          <div className="flex items-center gap-1.5 text-sm">
-            <Users className="w-3.5 h-3.5 text-muted-foreground" />
-            <span className="font-semibold">{(userStats.followers ?? 0).toLocaleString()}</span>
-          </div>
-          
-          <span className="text-muted-foreground/40">·</span>
-          
-          {/* Account Age */}
-          <div className="flex items-center gap-1.5 text-sm">
-            <Clock className="w-3.5 h-3.5 text-muted-foreground" />
-            <span className="font-semibold">{userStats.accountAgeLabel || 'Unknown'}</span>
-          </div>
-          
-          {/* Unverified email indicator */}
-          {!userStats.hasVerifiedEmail && (
-            <>
-              <span className="text-muted-foreground/40">·</span>
-              <span className="text-xs text-amber-500 font-medium">Unverified</span>
-            </>
-          )}
+      <div className="app-container">
+        <div className="flex items-center justify-center gap-3">
+        {/* Status orb */}
+        <div className={cn(
+          "w-2 h-2 rounded-full shrink-0",
+          statusColors[eligibilityStatus],
+          eligibilityStatus === 'good' && "animate-eligibility-pulse",
+          eligibilityStatus === 'warning' && "animate-eligibility-pulse-warning",
+          eligibilityStatus === 'error' && "animate-eligibility-pulse-blocked"
+        )} />
+        
+        {/* Karma */}
+        <div className="flex items-center gap-1.5 text-xs">
+          <TrendingUp className="w-3.5 h-3.5 text-muted-foreground" />
+          <span className="font-semibold">{(userStats.totalKarma ?? 0).toLocaleString()}</span>
+          <span className="text-muted-foreground text-xs">karma</span>
         </div>
-      </Tooltip>
+        
+        <span className="text-muted-foreground/40">·</span>
+        
+        {/* Followers */}
+        <div className="flex items-center gap-1.5 text-xs">
+          <Users className="w-3.5 h-3.5 text-muted-foreground" />
+          <span className="font-semibold">{(userStats.followers ?? 0).toLocaleString()}</span>
+        </div>
+        
+        <span className="text-muted-foreground/40">·</span>
+        
+        {/* Account Age */}
+        <div className="flex items-center gap-1.5 text-xs">
+          <Clock className="w-3.5 h-3.5 text-muted-foreground" />
+          <span className="font-semibold">{userStats.accountAgeLabel || 'Unknown'}</span>
+        </div>
+        
+        {/* Unverified email indicator */}
+        {!userStats.hasVerifiedEmail && (
+          <>
+            <span className="text-muted-foreground/40">·</span>
+            <span className="text-xs text-amber-500 font-medium">Unverified</span>
+          </>
+        )}
+        </div>
+      </div>
     </div>
   );
 };

--- a/components/posting-queue/FailedPostsPanel.tsx
+++ b/components/posting-queue/FailedPostsPanel.tsx
@@ -8,26 +8,9 @@
 import React from 'react';
 import { Button } from '@/components/ui/button';
 import { Tooltip } from '@/components/ui/tooltip';
-import {
-  AlertTriangle,
-  Tag,
-  Clock,
-  Ban,
-  Key,
-  FileText,
-  Lock,
-  Image,
-  Wifi,
-  RefreshCw,
-  Trash2,
-  Pencil,
-  X,
-  ChevronDown,
-  ChevronRight,
-  CheckCircle,
-} from 'lucide-react';
+import { RefreshCw, Pencil, X, ChevronDown, ChevronRight } from 'lucide-react';
 import { FailedPost, FailedPostsState } from '@/hooks/useFailedPosts';
-import { ErrorCategory, getActionLabel, getErrorGroupSummary } from '@/lib/errorClassification';
+import { ErrorCategory } from '@/lib/errorClassification';
 
 // ============================================================================
 // Types
@@ -45,58 +28,6 @@ interface FailedPostsPanelProps {
   /** Number of successfully posted items */
   successCount?: number;
 }
-
-// ============================================================================
-// Icon Mapping
-// ============================================================================
-
-const getErrorIcon = (iconName: string, className: string = 'h-4 w-4') => {
-  const icons: Record<string, React.ReactNode> = {
-    tag: <Tag className={className} />,
-    clock: <Clock className={className} />,
-    ban: <Ban className={className} />,
-    key: <Key className={className} />,
-    text: <FileText className={className} />,
-    lock: <Lock className={className} />,
-    image: <Image className={className} />,
-    wifi: <Wifi className={className} />,
-    alert: <AlertTriangle className={className} />,
-  };
-  return icons[iconName] || <AlertTriangle className={className} />;
-};
-
-const getCategoryIcon = (category: ErrorCategory, className: string = 'h-4 w-4') => {
-  switch (category) {
-    case 'fixable_now':
-      return <Pencil className={className} />;
-    case 'fixable_later':
-      return <Clock className={className} />;
-    case 'unfixable':
-      return <Ban className={className} />;
-  }
-};
-
-const getCategoryColor = (category: ErrorCategory): string => {
-  switch (category) {
-    case 'fixable_now':
-      return 'text-amber-500';
-    case 'fixable_later':
-      return 'text-blue-500';
-    case 'unfixable':
-      return 'text-red-500';
-  }
-};
-
-const getCategoryBgColor = (category: ErrorCategory): string => {
-  switch (category) {
-    case 'fixable_now':
-      return 'bg-amber-500/10 border-amber-500/30';
-    case 'fixable_later':
-      return 'bg-blue-500/10 border-blue-500/30';
-    case 'unfixable':
-      return 'bg-red-500/10 border-red-500/30';
-  }
-};
 
 const getCategoryLabel = (category: ErrorCategory): string => {
   switch (category) {
@@ -130,34 +61,13 @@ const FailedPostRow: React.FC<FailedPostRowProps> = ({
   const canRetry = post.error.category !== 'unfixable' || post.error.action === 'manual_retry';
 
   return (
-    <div className="flex items-center gap-2 px-3 py-2 border-b border-border/50 last:border-b-0 hover:bg-secondary/50 transition-colors">
-      {/* Error Icon */}
-      <Tooltip content={post.error.userMessage}>
-        <span className={getCategoryColor(post.error.category)}>
-          {getErrorIcon(post.error.icon, 'h-4 w-4')}
-        </span>
-      </Tooltip>
-
-      {/* Subreddit */}
-      <span className="text-sm flex-1 truncate">
-        r/{post.subreddit}
-      </span>
-
-      {/* Error Message */}
+    <div className="flex items-center gap-2 px-3 py-2 border-b border-border/50 last:border-b-0 hover:bg-secondary/40 transition-colors">
+      <span className="text-sm font-medium flex-1 truncate">r/{post.subreddit}</span>
       <Tooltip content={post.error.details || post.error.originalMessage}>
-        <span className="text-xs text-muted-foreground truncate max-w-[120px]">
+        <span className="text-xs text-muted-foreground truncate max-w-[160px]">
           {post.error.userMessage}
         </span>
       </Tooltip>
-
-      {/* Retry Count Badge */}
-      {post.retryCount > 0 && (
-        <span className="text-xs text-muted-foreground bg-secondary px-1.5 py-0.5 rounded">
-          {post.retryCount}x
-        </span>
-      )}
-
-      {/* Actions */}
       <div className="flex items-center gap-1">
         {canEdit && (
           <Button
@@ -165,7 +75,7 @@ const FailedPostRow: React.FC<FailedPostRowProps> = ({
             size="sm"
             onClick={onEdit}
             className="h-7 w-7 p-0 cursor-pointer hover:bg-amber-500/20 hover:text-amber-500"
-            title="Edit and retry"
+            title="Edit"
           >
             <Pencil className="h-3.5 w-3.5" />
           </Button>
@@ -201,8 +111,6 @@ interface CategorySectionProps {
   onRetryOne: (id: string) => void;
   onEdit: (post: FailedPost) => void;
   onRemove: (id: string) => void;
-  onRetryCategory: () => void;
-  onRemoveCategory: () => void;
 }
 
 const CategorySection: React.FC<CategorySectionProps> = ({
@@ -211,16 +119,13 @@ const CategorySection: React.FC<CategorySectionProps> = ({
   onRetryOne,
   onEdit,
   onRemove,
-  onRetryCategory,
-  onRemoveCategory,
 }) => {
   const [expanded, setExpanded] = React.useState(true);
-  const canRetry = category !== 'unfixable';
 
   if (posts.length === 0) return null;
 
   return (
-    <div className={`rounded-md border ${getCategoryBgColor(category)} overflow-hidden`}>
+    <div className="rounded-md border border-border overflow-hidden">
       {/* Category Header */}
       <button
         onClick={() => setExpanded(!expanded)}
@@ -233,38 +138,9 @@ const CategorySection: React.FC<CategorySectionProps> = ({
         ) : (
           <ChevronRight className="h-4 w-4 text-muted-foreground" />
         )}
-        <span className={getCategoryColor(category)}>
-          {getCategoryIcon(category, 'h-4 w-4')}
-        </span>
         <span className="text-sm font-medium flex-1 text-left">
           {getCategoryLabel(category)} ({posts.length})
         </span>
-        
-        {/* Bulk Actions */}
-        <div className="flex items-center gap-1" onClick={e => e.stopPropagation()}>
-          {canRetry && posts.length > 1 && (
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={onRetryCategory}
-              className="h-6 text-xs cursor-pointer hover:bg-blue-500/20 hover:text-blue-500"
-            >
-              <RefreshCw className="h-3 w-3 mr-1" />
-              Retry All
-            </Button>
-          )}
-          {posts.length > 1 && (
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={onRemoveCategory}
-              className="h-6 text-xs cursor-pointer hover:bg-red-500/20 hover:text-red-500"
-            >
-              <Trash2 className="h-3 w-3 mr-1" />
-              Remove
-            </Button>
-          )}
-        </div>
       </button>
 
       {/* Posts List */}
@@ -292,88 +168,19 @@ const CategorySection: React.FC<CategorySectionProps> = ({
 const FailedPostsPanel: React.FC<FailedPostsPanelProps> = ({
   state,
   onRetryOne,
-  onRetryCategory,
   onRetryAll,
   onEdit,
   onRemove,
-  onRemoveCategory,
   onClearAll,
-  successCount = 0,
 }) => {
-  const { posts, postsByCategory, categoryCounts } = state;
+  const { posts, postsByCategory } = state;
   const totalFailed = posts.length;
-  const retryableCount = categoryCounts.fixable_now + categoryCounts.fixable_later;
 
   if (totalFailed === 0) return null;
 
   return (
-    <div className="space-y-3">
-      {/* Summary Header */}
-      <div className="rounded-md bg-secondary/50 border border-border p-3">
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-3">
-            {successCount > 0 && (
-              <div className="flex items-center gap-1.5 text-green-500">
-                <CheckCircle className="h-4 w-4" />
-                <span className="text-sm font-medium">{successCount} posted</span>
-              </div>
-            )}
-            <div className="flex items-center gap-1.5 text-red-500">
-              <AlertTriangle className="h-4 w-4" />
-              <span className="text-sm font-medium">{totalFailed} failed</span>
-            </div>
-          </div>
-
-          {/* Global Actions */}
-          <div className="flex items-center gap-2">
-            {retryableCount > 0 && (
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={onRetryAll}
-                className="cursor-pointer border-blue-500/50 text-blue-500 hover:bg-blue-500/20"
-              >
-                <RefreshCw className="h-3.5 w-3.5 mr-1.5" />
-                Retry {retryableCount}
-              </Button>
-            )}
-            <Button
-              variant="ghost"
-              size="sm"
-              onClick={onClearAll}
-              className="cursor-pointer text-muted-foreground hover:text-red-500 hover:bg-red-500/10"
-            >
-              <Trash2 className="h-3.5 w-3.5 mr-1.5" />
-              Clear All
-            </Button>
-          </div>
-        </div>
-
-        {/* Category Summary */}
-        <div className="flex gap-4 mt-2 text-xs text-muted-foreground">
-          {categoryCounts.fixable_now > 0 && (
-            <span className="flex items-center gap-1">
-              <span className="w-2 h-2 rounded-full bg-amber-500" />
-              {categoryCounts.fixable_now} fixable
-            </span>
-          )}
-          {categoryCounts.fixable_later > 0 && (
-            <span className="flex items-center gap-1">
-              <span className="w-2 h-2 rounded-full bg-blue-500" />
-              {categoryCounts.fixable_later} retryable
-            </span>
-          )}
-          {categoryCounts.unfixable > 0 && (
-            <span className="flex items-center gap-1">
-              <span className="w-2 h-2 rounded-full bg-red-500" />
-              {categoryCounts.unfixable} unfixable
-            </span>
-          )}
-        </div>
-      </div>
-
+    <div className="space-y-2">
       {/* Category Sections */}
-      <div className="space-y-2">
         {/* Fixable Now - Show first */}
         <CategorySection
           category="fixable_now"
@@ -381,8 +188,6 @@ const FailedPostsPanel: React.FC<FailedPostsPanelProps> = ({
           onRetryOne={onRetryOne}
           onEdit={onEdit}
           onRemove={onRemove}
-          onRetryCategory={() => onRetryCategory('fixable_now')}
-          onRemoveCategory={() => onRemoveCategory('fixable_now')}
         />
 
         {/* Fixable Later */}
@@ -392,8 +197,6 @@ const FailedPostsPanel: React.FC<FailedPostsPanelProps> = ({
           onRetryOne={onRetryOne}
           onEdit={onEdit}
           onRemove={onRemove}
-          onRetryCategory={() => onRetryCategory('fixable_later')}
-          onRemoveCategory={() => onRemoveCategory('fixable_later')}
         />
 
         {/* Unfixable */}
@@ -403,10 +206,7 @@ const FailedPostsPanel: React.FC<FailedPostsPanelProps> = ({
           onRetryOne={onRetryOne}
           onEdit={onEdit}
           onRemove={onRemove}
-          onRetryCategory={() => onRetryCategory('unfixable')}
-          onRemoveCategory={() => onRemoveCategory('unfixable')}
         />
-      </div>
     </div>
   );
 };

--- a/components/settings/CategoryCard.tsx
+++ b/components/settings/CategoryCard.tsx
@@ -9,10 +9,12 @@ import { SortableContext, verticalListSortingStrategy } from '@dnd-kit/sortable'
 import { useSettingsContext } from './SettingsContext';
 import { Category } from './types';
 import SortableSubreddit from './SortableSubreddit';
+import { usePointerCoarse } from '@/hooks/usePointerCoarse';
 
 interface CategoryCardProps {
   category: Category;
   dragHandleProps: Record<string, unknown>;
+  dragContainerProps?: Record<string, unknown>;
   isDragging: boolean;
   canDelete: boolean;
 }
@@ -20,9 +22,11 @@ interface CategoryCardProps {
 const CategoryCard: React.FC<CategoryCardProps> = ({
   category,
   dragHandleProps,
+  dragContainerProps,
   isDragging,
   canDelete
 }) => {
+  const isCoarsePointer = usePointerCoarse();
   const [editingCategory, setEditingCategory] = React.useState(false);
   const [newSubredditName, setNewSubredditName] = React.useState('');
   const [isAddingSubreddit, setIsAddingSubreddit] = React.useState(false);
@@ -91,9 +95,12 @@ const CategoryCard: React.FC<CategoryCardProps> = ({
     }
   };
 
+  const containerDragProps = !isCoarsePointer ? dragContainerProps : undefined;
+
   return (
     <Card
       ref={setDroppableRef}
+      {...containerDragProps}
       className={`glass-card rounded-xl overflow-hidden transition-all duration-200 ${isDragging ? 'opacity-50 ring-2 ring-primary/50' : ''
         } ${isDropTarget ? 'ring-2 ring-primary bg-primary/5' : ''}`}
     >
@@ -101,7 +108,7 @@ const CategoryCard: React.FC<CategoryCardProps> = ({
         <div className="flex items-center gap-3">
           <div
             {...dragHandleProps}
-            className="cursor-grab hover:text-primary transition-colors"
+            className="cursor-grab hover:text-primary transition-colors touch-none select-none"
           >
             <GripVertical className="w-4 h-4 text-muted-foreground" aria-hidden="true" />
           </div>
@@ -152,6 +159,7 @@ const CategoryCard: React.FC<CategoryCardProps> = ({
                   size="sm"
                   variant="ghost"
                   onClick={() => setEditingCategory(true)}
+                  onPointerDown={(e) => e.stopPropagation()}
                   className="h-8 w-8 p-0 hover:bg-secondary cursor-pointer"
                   aria-label={`Edit ${category.name} category`}
                 >
@@ -162,6 +170,7 @@ const CategoryCard: React.FC<CategoryCardProps> = ({
                     size="sm"
                     variant="ghost"
                     onClick={handleDeleteCategory}
+                    onPointerDown={(e) => e.stopPropagation()}
                     className="h-8 w-8 p-0 text-red-400 hover:text-red-300 hover:bg-red-500/10 cursor-pointer"
                     aria-label={`Delete ${category.name} category`}
                   >

--- a/components/settings/SortableCategory.tsx
+++ b/components/settings/SortableCategory.tsx
@@ -31,6 +31,7 @@ const SortableCategory: React.FC<SortableCategoryProps> = ({ category, canDelete
       <CategoryCard
         category={category}
         dragHandleProps={{ ...attributes, ...listeners }}
+        dragContainerProps={{ ...attributes, ...listeners }}
         isDragging={isDragging}
         canDelete={canDelete}
       />

--- a/components/settings/SortableSubreddit.tsx
+++ b/components/settings/SortableSubreddit.tsx
@@ -42,6 +42,7 @@ const SortableSubreddit: React.FC<SortableSubredditProps> = ({
         subreddit={subreddit}
         category={category}
         dragHandleProps={{ ...attributes, ...listeners }}
+        dragContainerProps={{ ...attributes, ...listeners }}
         isDragging={isDragging}
       />
     </div>

--- a/components/settings/SubredditItem.tsx
+++ b/components/settings/SubredditItem.tsx
@@ -4,19 +4,23 @@ import { Input } from '@/components/ui/input';
 import { GripVertical, Edit2, X, Trash2, Loader2 } from 'lucide-react';
 import { useSettingsContext } from './SettingsContext';
 import { SubredditItem as SubredditItemType, Category } from './types';
+import { usePointerCoarse } from '@/hooks/usePointerCoarse';
 
 interface SubredditItemComponentProps {
   subreddit: SubredditItemType;
   category: Category;
   dragHandleProps: Record<string, unknown>;
+  dragContainerProps?: Record<string, unknown>;
   isDragging: boolean;
 }
 
 const SubredditItemComponent: React.FC<SubredditItemComponentProps> = ({
   subreddit,
   dragHandleProps,
+  dragContainerProps,
   isDragging
 }) => {
+  const isCoarsePointer = usePointerCoarse();
   const [editingSubreddit, setEditingSubreddit] = React.useState(false);
   const { updateSubreddit, deleteSubreddit, loading, errors } = useSettingsContext();
 
@@ -40,13 +44,18 @@ const SubredditItemComponent: React.FC<SubredditItemComponentProps> = ({
   const isLoading = loading[subreddit.subreddit_name.toLowerCase()];
   const error = errors[subreddit.subreddit_name.toLowerCase()];
 
+  const containerDragProps = !isCoarsePointer ? dragContainerProps : undefined;
+
   return (
-    <div className={`
-      flex items-center gap-2 px-3 py-2 rounded-lg bg-secondary/20 border border-border/30 
-      transition-all duration-200 hover:bg-secondary/30
-      ${isDragging ? 'opacity-50 ring-2 ring-primary/50' : ''}
-    `}>
-      <div {...dragHandleProps} className="cursor-grab">
+    <div
+      {...containerDragProps}
+      className={`
+        flex items-center gap-2 px-3 py-2 rounded-lg bg-secondary/20 border border-border/30 
+        transition-all duration-200 hover:bg-secondary/30
+        ${isDragging ? 'opacity-50 ring-2 ring-primary/50' : ''}
+      `}
+    >
+      <div {...dragHandleProps} className="cursor-grab touch-none select-none">
         <GripVertical className="w-3 h-3 text-muted-foreground" aria-hidden="true" />
       </div>
       
@@ -86,6 +95,7 @@ const SubredditItemComponent: React.FC<SubredditItemComponentProps> = ({
             size="sm"
             variant="ghost"
             onClick={() => setEditingSubreddit(true)}
+            onPointerDown={(e) => e.stopPropagation()}
             className="h-7 w-7 p-0 hover:bg-secondary cursor-pointer"
             aria-label={`Edit r/${subreddit.subreddit_name}`}
           >
@@ -95,6 +105,7 @@ const SubredditItemComponent: React.FC<SubredditItemComponentProps> = ({
             size="sm"
             variant="ghost"
             onClick={handleDeleteSubreddit}
+            onPointerDown={(e) => e.stopPropagation()}
             className="h-7 w-7 p-0 text-red-400 hover:text-red-300 hover:bg-red-500/10 cursor-pointer"
             aria-label={`Delete r/${subreddit.subreddit_name}`}
           >

--- a/components/subreddit-picker/SubredditCategoryList.tsx
+++ b/components/subreddit-picker/SubredditCategoryList.tsx
@@ -100,17 +100,17 @@ const SubredditCategoryList: React.FC<SubredditCategoryListProps> = ({
   }
 
   return (
-    <div className="rounded-md border border-border overflow-hidden">
+    <div className="space-y-4">
       {categorizedSubreddits.map(({ categoryName, subreddits }) => {
         const hasErrors = categoryHasErrors(subreddits);
         const isExpanded = expandedCategories.includes(categoryName);
         const selectedCount = subreddits.filter(s => selected.includes(s)).length;
 
         return (
-          <div key={categoryName} className="border-b border-border last:border-b-0">
+          <div key={categoryName} className="space-y-3">
             <button
               onClick={() => onToggleCategory(categoryName)}
-              className="w-full px-4 py-3 bg-secondary flex items-center justify-between hover:bg-secondary/80 transition-colors cursor-pointer"
+              className="w-full px-1 py-1.5 flex items-center justify-between hover:text-foreground transition-colors cursor-pointer"
               aria-expanded={isExpanded}
               aria-label={`${categoryName} category, ${subreddits.length} subreddits`}
             >
@@ -144,7 +144,7 @@ const SubredditCategoryList: React.FC<SubredditCategoryListProps> = ({
             </button>
 
             {isExpanded && (
-              <div>
+              <div className="space-y-2">
                 {subreddits.map((name) => {
                   const hasError = !!(showValidationErrors && hasMissingFlair(name));
                   const failedPost = failedPostsBySubreddit?.[name.toLowerCase()];

--- a/components/subreddit-picker/SubredditRow.tsx
+++ b/components/subreddit-picker/SubredditRow.tsx
@@ -270,11 +270,16 @@ const SubredditRow = React.memo(({
   const showTagControls = isSelected && hasRequiredStrings;
 
   return (
-    <div className="border-b border-border last:border-b-0">
+    <div
+      className={`
+        rounded-lg border border-border/60 bg-card/50 overflow-hidden
+        ${(hasError || hasValidationErrors) ? 'border-red-500/40' : ''}
+      `}
+    >
       {/* Main Row */}
       <div
         className={`
-          flex items-center justify-between px-3 sm:px-4 py-3.5 sm:py-3 transition-colors cursor-pointer gap-2
+          flex items-center justify-between px-3 sm:px-4 py-4 sm:py-3.5 transition-colors cursor-pointer gap-2
           ${(hasError || hasValidationErrors) ? 'bg-red-500/10' : 'hover:bg-secondary/50 active:bg-secondary/80'}
           active:scale-[0.99] transition-transform duration-75
         `}
@@ -319,7 +324,7 @@ const SubredditRow = React.memo(({
             {!isLoading && isSelected && canExpand && (
               <button
                 onClick={handleExpandClick}
-                className="bg-muted/60 hover:bg-muted text-muted-foreground hover:text-foreground rounded-full w-5 h-5 flex items-center justify-center transition-colors cursor-pointer flex-shrink-0"
+                className="bg-secondary/80 hover:bg-secondary text-foreground/70 hover:text-foreground rounded-full w-5 h-5 flex items-center justify-center transition-colors cursor-pointer flex-shrink-0"
                 aria-label="Community rules"
                 title="Community rules"
               >
@@ -329,7 +334,7 @@ const SubredditRow = React.memo(({
 
             {/* Flair Required Badge - Subtler */}
             {!isLoading && isSelected && flairRequired && (
-              <Badge variant="secondary" className="h-4.5 px-1.5 text-[9px] uppercase font-bold tracking-wider text-muted-foreground bg-muted hover:bg-muted flex-shrink-0" title="This community requires a flair">
+              <Badge variant="secondary" className="h-4.5 px-1.5 text-[9px] uppercase font-bold tracking-wider text-foreground/70 bg-secondary/80 hover:bg-secondary flex-shrink-0" title="This community requires a flair">
                 Flair
               </Badge>
             )}
@@ -485,7 +490,13 @@ const SubredditRow = React.memo(({
 
       {/* Row 2: Controls (Flair/Tag Selection) - Only when selected */}
       {isSelected && (showTagControls || flairOptions.length > 0) && (
-        <div className={`flex items-center gap-2 px-3 sm:px-4 pb-3 pt-1 ${(hasError || hasValidationErrors) ? 'bg-red-500/10' : ''}`} onClick={handleControlsClick}>
+        <div
+          className={`
+            flex items-center gap-2 px-3 sm:px-4 pb-3 pt-3 border-t border-border/60
+            ${(hasError || hasValidationErrors) ? 'bg-red-500/10 border-red-500/30' : 'bg-secondary/20'}
+          `}
+          onClick={handleControlsClick}
+        >
             {/* Flair Dropdown - Only show when there are flair options */}
             {flairOptions.length > 0 && (
               <Select

--- a/components/ui/dropdown-menu.tsx
+++ b/components/ui/dropdown-menu.tsx
@@ -14,7 +14,7 @@ const DropdownMenuContent = React.forwardRef<
       ref={ref}
       sideOffset={sideOffset}
       className={cn(
-        "z-50 min-w-[160px] overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-lg",
+        "z-[200] min-w-[160px] overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-lg",
         "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95",
         className
       )}

--- a/components/ui/select.tsx
+++ b/components/ui/select.tsx
@@ -73,7 +73,7 @@ const SelectContent = React.forwardRef<
     <SelectPrimitive.Content
       ref={ref}
       className={cn(
-        "relative z-50 max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]",
+        "relative z-[200] max-h-[--radix-select-content-available-height] min-w-[8rem] overflow-y-auto overflow-x-hidden rounded-md border bg-popover text-popover-foreground shadow-md data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 origin-[--radix-select-content-transform-origin]",
         position === "popper" &&
           "data-[side=bottom]:translate-y-1 data-[side=left]:-translate-x-1 data-[side=right]:translate-x-1 data-[side=top]:-translate-y-1",
         className

--- a/components/ui/toast.tsx
+++ b/components/ui/toast.tsx
@@ -98,7 +98,7 @@ const ToastViewport = React.forwardRef<
   <div
     ref={ref}
     className={cn(
-      "fixed bottom-0 right-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
+      "pointer-events-none fixed bottom-0 right-0 z-[100] flex max-h-screen w-full flex-col-reverse p-4 sm:bottom-0 sm:right-0 sm:top-auto sm:flex-col md:max-w-[420px]",
       className
     )}
     {...props}

--- a/hooks/usePointerCoarse.ts
+++ b/hooks/usePointerCoarse.ts
@@ -1,0 +1,41 @@
+import { useEffect, useState } from 'react';
+
+export const usePointerCoarse = (): boolean => {
+  const getInitial = () => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return false;
+    }
+    return window.matchMedia('(pointer: coarse)').matches;
+  };
+
+  const [isCoarse, setIsCoarse] = useState<boolean>(getInitial);
+
+  useEffect(() => {
+    if (typeof window === 'undefined' || typeof window.matchMedia !== 'function') {
+      return;
+    }
+    const media = window.matchMedia('(pointer: coarse)');
+
+    const handleChange = (event: MediaQueryListEvent) => {
+      setIsCoarse(event.matches);
+    };
+
+    if (typeof media.addEventListener === 'function') {
+      media.addEventListener('change', handleChange);
+    } else if (typeof media.addListener === 'function') {
+      media.addListener(handleChange);
+    }
+
+    setIsCoarse(media.matches);
+
+    return () => {
+      if (typeof media.removeEventListener === 'function') {
+        media.removeEventListener('change', handleChange);
+      } else if (typeof media.removeListener === 'function') {
+        media.removeListener(handleChange);
+      }
+    };
+  }, []);
+
+  return isCoarse;
+};

--- a/hooks/usePostingQueue.ts
+++ b/hooks/usePostingQueue.ts
@@ -195,16 +195,16 @@ export const usePostingQueue = ({
         formData.append('caption', caption);
         formData.append('prefixes', JSON.stringify(prefixes));
 
-        batch.forEach((item, index) => {
-          if (item.files && item.files.length > 0) {
-            item.files.forEach((file, fileIndex) => {
-              formData.append(`file_${index}_${fileIndex}`, file);
-            });
-            formData.append(`fileCount_${index}`, item.files.length.toString());
-          } else if (item.file) {
-            formData.append(`file_${index}`, item.file);
-          }
-        });
+        // Send shared files only once (not duplicated per item)
+        // All items in a batch share the same media files
+        const firstItemWithFiles = batch.find(item => item.files?.length || item.file);
+        if (firstItemWithFiles) {
+          const sharedFiles = firstItemWithFiles.files || (firstItemWithFiles.file ? [firstItemWithFiles.file] : []);
+          sharedFiles.forEach((file, fileIndex) => {
+            formData.append(`sharedFile_${fileIndex}`, file);
+          });
+          formData.append('sharedFileCount', sharedFiles.length.toString());
+        }
 
         res = await fetch('/api/queue', {
           method: 'POST',

--- a/hooks/useQueueJob.ts
+++ b/hooks/useQueueJob.ts
@@ -350,18 +350,25 @@ export function useQueueJob(): UseQueueJobReturn {
       formData.append('caption', submission.caption);
       formData.append('prefixes', JSON.stringify(submission.prefixes));
 
-      // Add files
-      submission.items.forEach((item, index) => {
-        if (item.files && item.files.length > 0) {
-          item.files.forEach((file, fileIndex) => {
-            formData.append(`file_${index}_${fileIndex}`, file);
-          });
-          formData.append(`fileCount_${index}`, item.files.length.toString());
-        } else if (item.file) {
-          formData.append(`file_${index}`, item.file);
-          formData.append(`fileCount_${index}`, '1');
-        }
-      });
+      // Add shared files (uploaded once, used by all items)
+      const firstItemWithFiles = submission.items.find(item => item.files?.length || item.file);
+      const sharedFiles = firstItemWithFiles
+        ? (firstItemWithFiles.files || (firstItemWithFiles.file ? [firstItemWithFiles.file] : []))
+        : [];
+
+      const hasMediaKind = submission.items.some(item =>
+        item.kind === 'image' || item.kind === 'video' || item.kind === 'gallery'
+      );
+      if (hasMediaKind && sharedFiles.length === 0) {
+        throw new Error('Please attach a media file for image, video, or gallery posts.');
+      }
+
+      if (sharedFiles.length > 0) {
+        sharedFiles.forEach((file, fileIndex) => {
+          formData.append(`sharedFile_${fileIndex}`, file);
+        });
+        formData.append('sharedFileCount', sharedFiles.length.toString());
+      }
 
       // Submit to API
       const response = await fetch('/api/queue/submit', {

--- a/lib/queueJob.ts
+++ b/lib/queueJob.ts
@@ -36,8 +36,21 @@ export interface QueueJobItem {
 /**
  * File reference stored in queue_jobs.file_paths JSONB.
  * Points to a file in Supabase Storage.
+ * 
+ * Storage path format: {username}/{date}/job_{shortId}/{prefix}_{fileIndex}_{fileName}
+ * 
+ * @property itemIndex - Index of the item this file belongs to, or -1 for shared files.
+ *                       Shared files (itemIndex = -1) are used by all items in the job.
+ *                       This avoids uploading the same media multiple times when posting
+ *                       to multiple subreddits.
+ * @property fileIndex - Index of the file within the item (for galleries) or shared files.
+ * @property storagePath - Full path in Supabase Storage bucket.
+ * @property originalName - Original filename uploaded by the user.
+ * @property mimeType - MIME type of the file.
+ * @property size - File size in bytes.
  */
 export interface QueueFileReference {
+  /** Item index this file belongs to, or -1 for shared files used by all items */
   itemIndex: number;
   fileIndex: number;
   storagePath: string;

--- a/lib/queueService.ts
+++ b/lib/queueService.ts
@@ -328,20 +328,33 @@ export async function isJobCancelled(jobId: string): Promise<boolean> {
 
 /**
  * Get files for a specific item in a job.
+ * 
+ * Files are organized as:
+ * - Shared files (itemIndex = -1): Used by all items in the job
+ * - Item-specific files: Used only by a specific item
+ * 
+ * This function returns shared files first, then any item-specific files.
  */
 export async function getJobItemFiles(
   job: QueueJob,
   itemIndex: number
 ): Promise<{ file: Blob; name: string; mimeType: string }[]> {
+  // Get shared files (itemIndex = -1) that are used by all items
+  const sharedFiles = job.file_paths.filter(f => f.itemIndex === -1);
+  
+  // Get item-specific files (for backward compatibility with old jobs)
   const itemFiles = job.file_paths.filter(f => f.itemIndex === itemIndex);
   
-  if (itemFiles.length === 0) {
+  // Combine: shared files first, then item-specific files
+  const allFiles = [...sharedFiles, ...itemFiles];
+  
+  if (allFiles.length === 0) {
     return [];
   }
   
   const files: { file: Blob; name: string; mimeType: string }[] = [];
   
-  for (const fileRef of itemFiles) {
+  for (const fileRef of allFiles) {
     try {
       const blob = await downloadQueueFile(fileRef.storagePath);
       files.push({

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -230,8 +230,14 @@ const QUEUE_FILES_BUCKET = 'queue-files';
 
 /**
  * Upload a file to Supabase Storage for queue processing.
- * @param jobId - The queue job ID
- * @param itemIndex - Index of the item in the queue
+ * 
+ * Folder structure: {username}/{date}/job_{shortId}/
+ * File naming:
+ *   - Shared files (itemIndex = -1): shared_{fileIndex}_{fileName}
+ *   - Item-specific files: item_{itemIndex}_{fileIndex}_{fileName}
+ * 
+ * @param jobFolder - The job folder path (format: username/date/job_shortId)
+ * @param itemIndex - Index of the item in the queue, or -1 for shared files
  * @param fileIndex - Index of the file within the item (for galleries)
  * @param file - The file buffer to upload
  * @param fileName - Original file name
@@ -239,7 +245,7 @@ const QUEUE_FILES_BUCKET = 'queue-files';
  * @returns The storage path of the uploaded file
  */
 export async function uploadQueueFile(
-  jobId: string,
+  jobFolder: string,
   itemIndex: number,
   fileIndex: number,
   file: Buffer,
@@ -247,7 +253,10 @@ export async function uploadQueueFile(
   mimeType: string
 ): Promise<string> {
   const client = createServerSupabaseClient();
-  const storagePath = `${jobId}/${itemIndex}_${fileIndex}_${fileName}`;
+  
+  // Use 'shared' prefix for shared files (itemIndex = -1), otherwise 'item_{index}'
+  const prefix = itemIndex === -1 ? 'shared' : `item_${itemIndex}`;
+  const storagePath = `${jobFolder}/${prefix}_${fileIndex}_${fileName}`;
   
   const { error } = await client.storage
     .from(QUEUE_FILES_BUCKET)

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -4,7 +4,7 @@ import { Home, ArrowLeft } from "lucide-react";
 
 const Custom404 = (): JSX.Element => {
   return (
-    <div className="min-h-screen flex items-center justify-center bg-background">
+    <div className="min-h-viewport flex items-center justify-center bg-background">
       <div className="text-center px-4">
         <h1 className="text-8xl font-bold text-orange-500">404</h1>
         <h2 className="mt-4 text-2xl font-semibold text-foreground">

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,7 +8,7 @@ import ErrorBoundary from "@/components/ErrorBoundary";
 import { Toaster } from "@/components/ui/toaster";
 import { ThemeProvider } from "@/contexts/ThemeContext";
 import { AuthProvider } from "@/contexts/AuthContext";
-import { MobileBottomNav } from "@/components/layout";
+import { AppFooter, MobileBottomNav } from "@/components/layout";
 import { inter, fontVariables } from "@/lib/fonts";
 import { swrConfig } from "@/lib/swr";
 
@@ -66,7 +66,7 @@ const RouteProgressBar = () => {
 
 /**
  * Wrapper that applies a subtle fade-in on every page mount.
- * Keeps transitions fast (200ms) so navigation feels instant but polished.
+ * Keeps transitions fast (150ms) so navigation feels instant but polished.
  */
 const PageTransition = ({ children }: { children: React.ReactNode }) => {
   const router = useRouter();
@@ -89,7 +89,7 @@ const PageTransition = ({ children }: { children: React.ReactNode }) => {
       className={
         transitionStage === "enter"
           ? "opacity-0 transition-none"
-          : "opacity-100 transition-opacity duration-200 ease-out"
+          : "opacity-100 transition-opacity duration-150 ease-out"
       }
     >
       {children}
@@ -112,6 +112,7 @@ export default function App({ Component, pageProps }: AppProps) {
                 <PageTransition>
                   <Component {...pageProps} />
                 </PageTransition>
+                <AppFooter />
                 <MobileBottomNav />
                 <Toaster />
               </div>

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -8,7 +8,7 @@ import ErrorBoundary from "@/components/ErrorBoundary";
 import { Toaster } from "@/components/ui/toaster";
 import { ThemeProvider } from "@/contexts/ThemeContext";
 import { AuthProvider } from "@/contexts/AuthContext";
-import { AppFooter, MobileBottomNav } from "@/components/layout";
+import { MobileBottomNav } from "@/components/layout";
 import { inter, fontVariables } from "@/lib/fonts";
 import { swrConfig } from "@/lib/swr";
 
@@ -98,10 +98,26 @@ const PageTransition = ({ children }: { children: React.ReactNode }) => {
 };
 
 export default function App({ Component, pageProps }: AppProps) {
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const ua = navigator.userAgent || "";
+    const isAndroid = /Android/i.test(ua);
+    const isWebView = ua.includes("wv");
+    const isStandalone =
+      typeof window.matchMedia === "function" &&
+      window.matchMedia("(display-mode: standalone)").matches;
+    if (isAndroid && (isWebView || isStandalone)) {
+      document.documentElement.classList.add("android-webview");
+    }
+  }, []);
+
   return (
     <>
       <Head>
-        <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" />
+        <meta
+          name="viewport"
+          content="width=device-width, initial-scale=1, maximum-scale=1, user-scalable=no, viewport-fit=cover"
+        />
       </Head>
       <ErrorBoundary>
         <SWRConfig value={swrConfig}>
@@ -112,7 +128,6 @@ export default function App({ Component, pageProps }: AppProps) {
                 <PageTransition>
                   <Component {...pageProps} />
                 </PageTransition>
-                <AppFooter />
                 <MobileBottomNav />
                 <Toaster />
               </div>

--- a/pages/admin.tsx
+++ b/pages/admin.tsx
@@ -211,7 +211,7 @@ export default function AdminPanel() {
       <div className="min-h-viewport bg-background">
         {/* Command Center Header */}
         <header className="sticky top-0 z-50 border-b border-border/40 bg-background/80 backdrop-blur-xl pt-[env(safe-area-inset-top)]">
-          <div className="container mx-auto px-4 sm:px-6">
+          <div className="app-container">
             <div className="flex h-16 items-center gap-4">
               {/* Back Button */}
               <Button
@@ -270,7 +270,7 @@ export default function AdminPanel() {
         </header>
 
         {/* Main Content */}
-        <main className="container mx-auto px-4 sm:px-6 py-6 max-w-6xl">
+        <main className="app-container py-6 max-w-6xl">
           <Tabs value={activeTab} onValueChange={handleTabChange} className="w-full">
             {/* Tab Navigation */}
             <div className="mb-6 overflow-x-auto pb-2 -mx-4 px-4 sm:mx-0 sm:px-0">

--- a/pages/admin.tsx
+++ b/pages/admin.tsx
@@ -169,7 +169,7 @@ export default function AdminPanel() {
   // Loading state - simple centered spinner
   if (authLoading || isLoading) {
     return (
-      <div className="min-h-screen bg-background flex items-center justify-center">
+      <div className="min-h-viewport bg-background flex items-center justify-center">
         <Loader2 className="w-8 h-8 animate-spin text-cyan-400" />
       </div>
     );
@@ -178,7 +178,7 @@ export default function AdminPanel() {
   // Error state (including access denied)
   if (error) {
     return (
-      <div className="min-h-screen bg-background flex items-center justify-center p-4">
+      <div className="min-h-viewport bg-background flex items-center justify-center p-4">
         <div className="flex flex-col items-center gap-3 text-center">
           <XCircle className="w-10 h-10 text-red-400" />
           <p className="text-foreground font-medium">{error}</p>
@@ -194,7 +194,7 @@ export default function AdminPanel() {
   // No data state
   if (!data) {
     return (
-      <div className="min-h-screen bg-background flex items-center justify-center">
+      <div className="min-h-viewport bg-background flex items-center justify-center">
         <p className="text-muted-foreground">No data available</p>
       </div>
     );
@@ -208,7 +208,7 @@ export default function AdminPanel() {
         <meta name="robots" content="noindex, nofollow" />
       </Head>
 
-      <div className="min-h-screen bg-background">
+      <div className="min-h-viewport bg-background">
         {/* Command Center Header */}
         <header className="sticky top-0 z-50 border-b border-border/40 bg-background/80 backdrop-blur-xl pt-[env(safe-area-inset-top)]">
           <div className="container mx-auto px-4 sm:px-6">

--- a/pages/analytics.tsx
+++ b/pages/analytics.tsx
@@ -13,7 +13,7 @@ export default function AnalyticsRedirect() {
   }, [router]);
 
   return (
-    <div className="min-h-screen bg-background flex items-center justify-center">
+    <div className="min-h-viewport bg-background flex items-center justify-center">
       <p className="text-muted-foreground">Redirecting to Admin Panel...</p>
     </div>
   );

--- a/pages/api/queue.ts
+++ b/pages/api/queue.ts
@@ -240,18 +240,19 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
       }
       
       try {
-        // Get files if uploaded for this item (support multiple files)
+        // Get files for this item (support shared files and multiple files)
         const itemFiles: File[] = [];
         
-        // Check if there's a fileCount for this item (multiple files)
-        const fileCountKey = `fileCount_${i}`;
-        const fileCountField = Array.isArray(fields[fileCountKey]) ? fields[fileCountKey][0] : fields[fileCountKey];
-        const fileCount = fileCountField ? parseInt(fileCountField as string) : 1;
+        // Check for shared files first (uploaded once, used by all items)
+        // Frontend sends: sharedFile_0, sharedFile_1, etc. with sharedFileCount
+        const sharedFileCountField = Array.isArray(fields.sharedFileCount) 
+          ? fields.sharedFileCount[0] 
+          : fields.sharedFileCount;
+        const sharedFileCount = sharedFileCountField ? parseInt(sharedFileCountField as string) : 0;
         
-        
-        // Collect all files for this item
-        for (let fileIndex = 0; fileIndex < fileCount; fileIndex++) {
-          const fileKey = `file_${i}_${fileIndex}`;
+        // Collect shared files (same files used for all items in the batch)
+        for (let fileIndex = 0; fileIndex < sharedFileCount; fileIndex++) {
+          const fileKey = `sharedFile_${fileIndex}`;
           if (files[fileKey]) {
             const uploadedFile = Array.isArray(files[fileKey]) ? files[fileKey][0] : files[fileKey];
             if (uploadedFile) {
@@ -265,7 +266,28 @@ export default async function handler(req: NextApiRequest, res: NextApiResponse)
           }
         }
         
-        // Fallback: check for single file with old format
+        // Fallback: check for old per-item file format (file_0_0, file_0_1, etc.)
+        if (itemFiles.length === 0) {
+          const fileCountKey = `fileCount_${i}`;
+          const fileCountField = Array.isArray(fields[fileCountKey]) ? fields[fileCountKey][0] : fields[fileCountKey];
+          const fileCount = fileCountField ? parseInt(fileCountField as string) : 1;
+          
+          for (let fileIndex = 0; fileIndex < fileCount; fileIndex++) {
+            const fileKey = `file_${i}_${fileIndex}`;
+            if (files[fileKey]) {
+              const uploadedFile = Array.isArray(files[fileKey]) ? files[fileKey][0] : files[fileKey];
+              if (uploadedFile) {
+                const buffer = fs.readFileSync(uploadedFile.filepath);
+                const file = new File([buffer], uploadedFile.originalFilename || 'upload', {
+                  type: uploadedFile.mimetype || 'application/octet-stream'
+                });
+                itemFiles.push(file);
+              }
+            }
+          }
+        }
+        
+        // Fallback: check for single file with oldest format (file_0)
         if (itemFiles.length === 0) {
           const fileKey = `file_${i}`;
           if (files[fileKey]) {

--- a/pages/api/queue/submit.ts
+++ b/pages/api/queue/submit.ts
@@ -93,98 +93,66 @@ export default async function handler(
       }
     }
 
-    // Generate a temporary job ID for file uploads
-    // We'll use this as a folder name in storage
-    const tempJobId = `job_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+    // Generate meaningful folder path for file uploads
+    // Format: {username}/{date}/job_{shortId}/
+    const redditUsername = req.cookies['reddit_username'] || 'unknown';
+    const dateStr = new Date().toISOString().split('T')[0]; // YYYY-MM-DD
+    const shortId = Math.random().toString(36).slice(2, 8);
+    const jobFolder = `${redditUsername}/${dateStr}/job_${shortId}`;
 
-    // Process files and upload to Supabase Storage
+    // Process shared files (uploaded once, used by all items)
     const filePaths: QueueFileReference[] = [];
     const jobItems: QueueJobItem[] = [];
 
+    // Get shared file count from form data
+    const sharedFileCountField = Array.isArray(fields.sharedFileCount) 
+      ? fields.sharedFileCount[0] 
+      : fields.sharedFileCount;
+    const sharedFileCount = sharedFileCountField ? parseInt(sharedFileCountField as string) : 0;
+
+    // Upload shared files once (itemIndex = -1 indicates shared files)
+    for (let fileIndex = 0; fileIndex < sharedFileCount; fileIndex++) {
+      const fileKey = `sharedFile_${fileIndex}`;
+      const uploadedFile = files[fileKey];
+      
+      if (!uploadedFile) continue;
+
+      const file = Array.isArray(uploadedFile) ? uploadedFile[0] : uploadedFile;
+      if (!file || !file.filepath) continue;
+
+      // Check file size
+      if (file.size > QUEUE_LIMITS.MAX_SINGLE_FILE_SIZE_MB * 1024 * 1024) {
+        return res.status(400).json({
+          success: false,
+          error: `File "${file.originalFilename}" exceeds maximum size of ${QUEUE_LIMITS.MAX_SINGLE_FILE_SIZE_MB}MB`,
+        });
+      }
+
+      // Upload to Supabase Storage (shared files use itemIndex = -1)
+      const buffer = fs.readFileSync(file.filepath);
+      const storagePath = await uploadQueueFile(
+        jobFolder,
+        -1, // -1 indicates this is a shared file
+        fileIndex,
+        buffer,
+        file.originalFilename || 'file',
+        file.mimetype || 'application/octet-stream'
+      );
+
+      filePaths.push({
+        itemIndex: -1, // Shared file indicator
+        fileIndex,
+        storagePath,
+        originalName: file.originalFilename || 'file',
+        mimeType: file.mimetype || 'application/octet-stream',
+        size: file.size || buffer.length,
+      });
+    }
+
+    // Build job items (all items share the same files)
     for (let itemIndex = 0; itemIndex < parsedItems.length; itemIndex++) {
       const item = parsedItems[itemIndex];
       
-      // Count files for this item
-      const fileCountKey = `fileCount_${itemIndex}`;
-      const fileCountField = Array.isArray(fields[fileCountKey]) 
-        ? fields[fileCountKey][0] 
-        : fields[fileCountKey];
-      const expectedFileCount = fileCountField ? parseInt(fileCountField as string) : 0;
-
-      let actualFileCount = 0;
-
-      // Upload files for this item
-      for (let fileIndex = 0; fileIndex < Math.max(expectedFileCount, 20); fileIndex++) {
-        const fileKey = `file_${itemIndex}_${fileIndex}`;
-        const uploadedFile = files[fileKey];
-        
-        if (!uploadedFile) {
-          // Also try single file format
-          if (fileIndex === 0) {
-            const singleFileKey = `file_${itemIndex}`;
-            const singleFile = files[singleFileKey];
-            if (singleFile) {
-              const file = Array.isArray(singleFile) ? singleFile[0] : singleFile;
-              if (file && file.filepath) {
-                const buffer = fs.readFileSync(file.filepath);
-                const storagePath = await uploadQueueFile(
-                  tempJobId,
-                  itemIndex,
-                  0,
-                  buffer,
-                  file.originalFilename || 'file',
-                  file.mimetype || 'application/octet-stream'
-                );
-                
-                filePaths.push({
-                  itemIndex,
-                  fileIndex: 0,
-                  storagePath,
-                  originalName: file.originalFilename || 'file',
-                  mimeType: file.mimetype || 'application/octet-stream',
-                  size: file.size || buffer.length,
-                });
-                actualFileCount = 1;
-              }
-            }
-          }
-          continue;
-        }
-
-        const file = Array.isArray(uploadedFile) ? uploadedFile[0] : uploadedFile;
-        if (!file || !file.filepath) continue;
-
-        // Check file size
-        if (file.size > QUEUE_LIMITS.MAX_SINGLE_FILE_SIZE_MB * 1024 * 1024) {
-          return res.status(400).json({
-            success: false,
-            error: `File "${file.originalFilename}" exceeds maximum size of ${QUEUE_LIMITS.MAX_SINGLE_FILE_SIZE_MB}MB`,
-          });
-        }
-
-        // Upload to Supabase Storage
-        const buffer = fs.readFileSync(file.filepath);
-        const storagePath = await uploadQueueFile(
-          tempJobId,
-          itemIndex,
-          fileIndex,
-          buffer,
-          file.originalFilename || 'file',
-          file.mimetype || 'application/octet-stream'
-        );
-
-        filePaths.push({
-          itemIndex,
-          fileIndex,
-          storagePath,
-          originalName: file.originalFilename || 'file',
-          mimeType: file.mimetype || 'application/octet-stream',
-          size: file.size || buffer.length,
-        });
-        actualFileCount++;
-      }
-
-      // Build job item (without File objects)
       jobItems.push({
         subreddit: item.subreddit,
         flairId: item.flairId,
@@ -192,7 +160,7 @@ export default async function handler(
         kind: item.kind,
         url: item.url,
         text: item.text,
-        fileCount: actualFileCount,
+        fileCount: sharedFileCount, // All items use the shared files
       });
     }
 

--- a/pages/checkout/index.tsx
+++ b/pages/checkout/index.tsx
@@ -249,7 +249,7 @@ export default function CheckoutPage() {
         <meta name="robots" content="noindex" />
       </Head>
 
-      <div className="min-h-screen bg-[#0a0a0a]">
+      <div className="min-h-viewport bg-[#0a0a0a]">
         {/* Header */}
         <header className="border-b border-zinc-800 bg-[#0a0a0a]/80 backdrop-blur-sm sticky top-0 z-10 pt-[env(safe-area-inset-top)]">
           <div className="max-w-2xl mx-auto px-4 py-4 flex items-center gap-4">

--- a/pages/checkout/success.tsx
+++ b/pages/checkout/success.tsx
@@ -9,7 +9,7 @@ export default function CheckoutSuccess() {
       <Head>
         <title>Thank you - Reddit Multi Poster</title>
       </Head>
-      <div className="min-h-screen bg-[#0a0a0a] flex flex-col items-center justify-center p-4">
+      <div className="min-h-viewport bg-[#0a0a0a] flex flex-col items-center justify-center p-4">
         <div className="max-w-md w-full text-center space-y-6">
           <div className="flex justify-center">
             <CheckCircle className="h-16 w-16 text-green-500" aria-hidden="true" />

--- a/pages/help.tsx
+++ b/pages/help.tsx
@@ -66,7 +66,7 @@ const HelpPage: React.FC = () => {
       <Head>
         <title>Help & Feedback | Poststation</title>
       </Head>
-      <div className="min-h-screen bg-background pb-20 md:pb-0">
+      <div className="min-h-viewport bg-background safe-bottom">
         <div className="max-w-2xl mx-auto px-4 pt-8 pb-4">
           <h1 className="text-xl font-bold flex items-center gap-2 mb-6">
             <HelpCircle className="w-5 h-5 text-primary" />

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -12,7 +12,7 @@ import PostComposer from '../components/PostComposer';
 import { AppLoader, Skeleton, SubredditRowSkeleton, CardSkeleton } from '@/components/ui/loader';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Button } from '@/components/ui/button';
-import { AppHeader, MobileUserStatsBanner } from '@/components/layout';
+import { AppHeader, MobileUserStatsBanner, AppFooter } from '@/components/layout';
 import { useHomePageState } from '@/hooks/useHomePageState';
 import { useFailedPosts, FailedPost } from '@/hooks/useFailedPosts';
 import { useSubredditFlairData } from '@/hooks/useSubredditFlairData';
@@ -623,6 +623,8 @@ export default function Home() {
             </div>
           </main>
 
+          {/* Footer */}
+          <AppFooter />
         </div>
       )}
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -12,7 +12,7 @@ import PostComposer from '../components/PostComposer';
 import { AppLoader, Skeleton, SubredditRowSkeleton, CardSkeleton } from '@/components/ui/loader';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Button } from '@/components/ui/button';
-import { AppHeader, MobileUserStatsBanner, AppFooter } from '@/components/layout';
+import { AppHeader, MobileUserStatsBanner } from '@/components/layout';
 import { useHomePageState } from '@/hooks/useHomePageState';
 import { useFailedPosts, FailedPost } from '@/hooks/useFailedPosts';
 import { useSubredditFlairData } from '@/hooks/useSubredditFlairData';
@@ -450,7 +450,7 @@ export default function Home() {
       {showLoader && <AppLoader exiting={loaderExiting} />}
 
       {!authLoading && (
-        <div className="min-h-screen bg-background flex flex-col noise-texture noise-subtle">
+        <div className="min-h-viewport bg-background flex flex-col noise-texture noise-subtle">
           {/* Header */}
           <AppHeader
             userName={me?.name}
@@ -471,7 +471,7 @@ export default function Home() {
 
           <PwaOnboarding hasQueueItems={items.length > 0} />
 
-            <main className="flex-1 container mx-auto px-4 sm:px-6 py-4 lg:py-8 max-w-2xl lg:max-w-7xl safe-bottom pb-20 md:pb-0">
+            <main className="flex-1 container mx-auto px-4 sm:px-6 py-4 lg:py-8 max-w-2xl lg:max-w-7xl safe-bottom">
             <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 lg:gap-8 items-start">
 
               {/* Left Column: Create Post */}
@@ -623,8 +623,6 @@ export default function Home() {
             </div>
           </main>
 
-          {/* Footer */}
-          <AppFooter />
         </div>
       )}
 

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -484,13 +484,13 @@ export default function Home() {
 
           <PwaOnboarding hasQueueItems={items.length > 0} />
 
-            <main className="flex-1 container mx-auto px-4 sm:px-6 py-4 lg:py-8 max-w-2xl lg:max-w-7xl safe-bottom">
-            <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 lg:gap-8 items-start">
+            <main className="flex-1 app-container py-4 md:py-6 lg:py-8 max-w-2xl lg:max-w-7xl safe-bottom">
+            <div className="grid grid-cols-1 lg:grid-cols-2 gap-0 items-start lg:divide-x lg:divide-border/50">
 
               {/* Left Column: Create Post */}
-              <div className="lg:space-y-8">
+              <div className="lg:pr-6">
                 {/* Section Header - Desktop only */}
-                <h2 className="text-xl mb-4 font-semibold tracking-tight hidden lg:block">Your post</h2>
+                <h2 className="text-xl mb-4 font-semibold tracking-tight hidden lg:block ">Your post</h2>
 
                 {/* Media Section - No card wrapper, flowing layout */}
                 <section className="space-y-4 mb-4">
@@ -533,6 +533,8 @@ export default function Home() {
                   />
                 </section>
 
+                <div className="border-t border-border/50 my-6" aria-hidden="true" />
+
                 {/* Title Section - No card wrapper, flowing layout */}
                 <section className="space-y-4 mb-4">
                   <h3 className="text-base lg:text-lg font-semibold tracking-tight">Title & Body</h3>
@@ -547,16 +549,17 @@ export default function Home() {
                 </section>
               </div>
 
+              <div className="border-t border-border/50 my-4 lg:hidden" aria-hidden="true" />
+
               {/* Right Column: Communities & Queue */}
-              <div className="space-y-4 lg:space-y-8">
+              <div className="lg:pl-6">
                 {/* Section Header - Desktop only */}
-                <h2 className="text-xl font-semibold tracking-tight hidden lg:block">Where to post</h2>
+                <h2 className="text-xl font-semibold tracking-tight hidden lg:block mb-4 lg:mb-6">Where to post</h2>
 
                 {/* Communities Section */}
                 <section 
                   className={cn(
-                    "space-y-4",
-                    "lg:rounded-lg lg:border lg:border-border/50 lg:p-6 lg:bg-card/50"
+                    "space-y-4"
                   )}
                 >
                   <div className="flex items-center justify-between">
@@ -616,12 +619,13 @@ export default function Home() {
                   )}
                 </section>
 
+                <div className="border-t border-border/50 my-4 lg:my-6" aria-hidden="true" />
+
                 {/* Queue Section */}
                 <section 
                   className={cn(
                     "lg:sticky lg:top-20",
-                    "lg:rounded-lg lg:border lg:border-border/50 lg:p-6 lg:bg-card/50",
-                    "pt-6  border-t border-border/50 lg:border-t-0"
+                    "pt-2 lg:pt-0"
                   )}
                 >
                   <PostingQueue

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -91,6 +91,7 @@ export default function Home() {
   const [upgradeLoading, setUpgradeLoading] = React.useState(false);
   const [showUpgradeModal, setShowUpgradeModal] = React.useState(false);
   const [upgradeModalContext, setUpgradeModalContext] = React.useState<{ title?: string; message: string } | undefined>(undefined);
+  const [mediaResetCounter, setMediaResetCounter] = React.useState(0);
 
   // Smooth loader exit: keep AppLoader mounted briefly to fade out
   const [showLoader, setShowLoader] = React.useState(true);
@@ -139,6 +140,18 @@ export default function Home() {
     clearSelection,
     clearAllState,
   } = useHomePageState({ authMe: me ?? undefined });
+
+  const resetMedia = React.useCallback(() => {
+    setMediaUrl('');
+    setMediaFiles([]);
+    setMediaMode('file');
+    setMediaResetCounter((prev) => prev + 1);
+  }, [setMediaUrl, setMediaFiles, setMediaMode]);
+
+  const handleClearAll = React.useCallback(() => {
+    clearAllState();
+    setMediaResetCounter((prev) => prev + 1);
+  }, [clearAllState]);
 
   // Failed posts tracking for inline error display
   const failedPostsHook = useFailedPosts();
@@ -512,7 +525,12 @@ export default function Home() {
                       </button>
                     </div>
                   </div>
-                  <MediaUpload onUrl={setMediaUrl} onFile={setMediaFiles} mode={mediaMode} />
+                  <MediaUpload
+                    onUrl={setMediaUrl}
+                    onFile={setMediaFiles}
+                    mode={mediaMode}
+                    resetSignal={mediaResetCounter}
+                  />
                 </section>
 
                 {/* Title Section - No card wrapper, flowing layout */}
@@ -614,7 +632,8 @@ export default function Home() {
                     hasFlairErrors={hasFlairErrors}
                     onPostAttempt={handlePostWithLimitCheck}
                     onUnselectSuccessItems={handleUnselectSuccessItems}
-                    onClearAll={clearAllState}
+                    onClearAll={handleClearAll}
+                    onResetMedia={resetMedia}
                     onResultsAvailable={handleResultsAvailable}
                     onValidationChange={handleQueueValidationChange}
                   />

--- a/pages/login.tsx
+++ b/pages/login.tsx
@@ -57,7 +57,7 @@ export default function Login() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-[#0a0a0a] flex items-center justify-center">
+      <div className="min-h-viewport bg-[#0a0a0a] flex items-center justify-center">
         <div className="w-10 h-10 border-2 border-orange-500/30 border-t-orange-500 rounded-full animate-spin" />
       </div>
     );
@@ -90,7 +90,7 @@ export default function Login() {
         <meta name="twitter:image" content="https://reddit-multi-poster.vercel.app/og-image.svg" />
       </Head>
 
-      <div className="min-h-screen relative overflow-hidden">
+      <div className="min-h-viewport relative overflow-hidden">
         {/* Animated gradient background */}
         <div className="absolute inset-0 bg-[#0a0a0a]">
           <div className="absolute inset-0 bg-gradient-to-br from-[#0a0a0a] via-[#12121a] to-[#1a1a2e]" />
@@ -102,7 +102,7 @@ export default function Login() {
         </div>
 
         {/* Content */}
-        <div className="relative z-10 min-h-screen flex flex-col items-center justify-center px-4 py-12">
+        <div className="relative z-10 min-h-full flex flex-col items-center justify-center px-4 py-6 sm:py-12">
           {/* Glass card */}
           <div className="w-full max-w-md">
             <div className="p-4 sm:p-8 sm:backdrop-blur-xl sm:bg-white/[0.03] sm:border sm:border-white/[0.08] sm:rounded-3xl sm:shadow-[0_0_80px_rgba(255,69,0,0.05),0_25px_50px_-12px_rgba(0,0,0,0.5)]">

--- a/pages/privacy.tsx
+++ b/pages/privacy.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
 import { ArrowLeft } from 'lucide-react';
+import { AppFooter } from '@/components/layout';
 
 const LAST_UPDATED = 'February 5, 2026';
 
@@ -171,6 +172,7 @@ export default function Privacy() {
           </article>
         </main>
 
+        <AppFooter />
       </div>
     </>
   );

--- a/pages/privacy.tsx
+++ b/pages/privacy.tsx
@@ -18,7 +18,7 @@ export default function Privacy() {
       <div className="min-h-viewport bg-background flex flex-col">
         {/* Simple Header */}
         <header className="sticky top-0 z-50 bg-background/80 backdrop-blur-md border-b border-border/50">
-          <div className="container mx-auto px-4 py-4 max-w-3xl">
+          <div className="app-container py-4 max-w-3xl">
             <Link 
               href="/" 
               className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
@@ -30,7 +30,7 @@ export default function Privacy() {
         </header>
 
         {/* Content */}
-        <main className="flex-1 container mx-auto px-4 py-8 sm:py-12 max-w-3xl">
+        <main className="flex-1 app-container py-8 sm:py-12 max-w-3xl">
           <article className="prose prose-neutral dark:prose-invert prose-headings:font-semibold prose-a:text-primary prose-a:no-underline hover:prose-a:underline max-w-none">
             <h1 className="text-3xl sm:text-4xl mb-2">Privacy Policy</h1>
             <p className="text-muted-foreground text-sm mt-0 mb-8">

--- a/pages/privacy.tsx
+++ b/pages/privacy.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
 import { ArrowLeft } from 'lucide-react';
-import { AppFooter } from '@/components/layout';
 
 const LAST_UPDATED = 'February 5, 2026';
 
@@ -15,7 +14,7 @@ export default function Privacy() {
         <meta name="robots" content="index, follow" />
       </Head>
 
-      <div className="min-h-screen bg-background flex flex-col">
+      <div className="min-h-viewport bg-background flex flex-col">
         {/* Simple Header */}
         <header className="sticky top-0 z-50 bg-background/80 backdrop-blur-md border-b border-border/50">
           <div className="container mx-auto px-4 py-4 max-w-3xl">
@@ -172,7 +171,6 @@ export default function Privacy() {
           </article>
         </main>
 
-        <AppFooter />
       </div>
     </>
   );

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -262,7 +262,7 @@ export default function Settings() {
   // Show loading state
   if (authLoading || !isLoaded) {
     return (
-      <div className="min-h-screen bg-background flex items-center justify-center">
+      <div className="min-h-viewport bg-background flex items-center justify-center">
         <div className="flex flex-col items-center gap-4">
           <Loader2 className="w-8 h-8 animate-spin text-primary" />
           <p className="text-muted-foreground">Loading…</p>
@@ -290,7 +290,7 @@ export default function Settings() {
           <meta name="robots" content="noindex, nofollow" />
         </Head>
 
-        <div className="min-h-screen bg-background">
+        <div className="min-h-viewport bg-background">
           {/* Header */}
           <header className="sticky top-0 z-50 border-b border-border/40 bg-background/80 backdrop-blur-xl pt-[env(safe-area-inset-top)]">
             <div className="container mx-auto px-4 sm:px-6">
@@ -333,7 +333,7 @@ export default function Settings() {
           </header>
 
           {/* Main Content */}
-          <main className="container mx-auto px-4 sm:px-6 py-4 sm:py-6 max-w-3xl pb-20 md:pb-0">
+          <main className="container mx-auto px-4 sm:px-6 py-4 sm:py-6 max-w-3xl safe-bottom">
             <div className="space-y-6">
               {/* Actions */}
               <div className="flex flex-col sm:flex-row gap-3">

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -300,7 +300,7 @@ export default function Settings() {
         <div className="min-h-viewport bg-background">
           {/* Header */}
           <header className="sticky top-0 z-50 border-b border-border/40 bg-background/80 backdrop-blur-xl pt-[env(safe-area-inset-top)]">
-            <div className="container mx-auto px-4 sm:px-6">
+            <div className="app-container">
               <div className="flex h-14 items-center gap-4">
                 <Button
                   variant="ghost"
@@ -340,7 +340,7 @@ export default function Settings() {
           </header>
 
           {/* Main Content */}
-          <main className="container mx-auto px-4 sm:px-6 py-4 sm:py-6 max-w-3xl safe-bottom">
+          <main className="app-container py-4 sm:py-6 max-w-3xl safe-bottom">
             <div className="space-y-6">
               {/* Actions */}
               <div className="flex flex-col sm:flex-row gap-3">

--- a/pages/settings.tsx
+++ b/pages/settings.tsx
@@ -17,6 +17,7 @@ import {
   closestCenter,
   KeyboardSensor,
   PointerSensor,
+  TouchSensor,
   useSensor,
   useSensors,
   DragOverlay,
@@ -120,6 +121,12 @@ export default function Settings() {
     useSensor(PointerSensor, {
       activationConstraint: {
         distance: 8,
+      },
+    }),
+    useSensor(TouchSensor, {
+      activationConstraint: {
+        delay: 200,
+        tolerance: 8,
       },
     }),
     useSensor(KeyboardSensor, {

--- a/pages/terms.tsx
+++ b/pages/terms.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
 import { ArrowLeft } from 'lucide-react';
+import { AppFooter } from '@/components/layout';
 
 const LAST_UPDATED = 'February 5, 2026';
 
@@ -205,6 +206,7 @@ export default function Terms() {
           </article>
         </main>
 
+        <AppFooter />
       </div>
     </>
   );

--- a/pages/terms.tsx
+++ b/pages/terms.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import Head from 'next/head';
 import Link from 'next/link';
 import { ArrowLeft } from 'lucide-react';
-import { AppFooter } from '@/components/layout';
 
 const LAST_UPDATED = 'February 5, 2026';
 
@@ -15,7 +14,7 @@ export default function Terms() {
         <meta name="robots" content="index, follow" />
       </Head>
 
-      <div className="min-h-screen bg-background flex flex-col">
+      <div className="min-h-viewport bg-background flex flex-col">
         {/* Simple Header */}
         <header className="sticky top-0 z-50 bg-background/80 backdrop-blur-md border-b border-border/50">
           <div className="container mx-auto px-4 py-4 max-w-3xl">
@@ -206,7 +205,6 @@ export default function Terms() {
           </article>
         </main>
 
-        <AppFooter />
       </div>
     </>
   );

--- a/pages/terms.tsx
+++ b/pages/terms.tsx
@@ -18,7 +18,7 @@ export default function Terms() {
       <div className="min-h-viewport bg-background flex flex-col">
         {/* Simple Header */}
         <header className="sticky top-0 z-50 bg-background/80 backdrop-blur-md border-b border-border/50">
-          <div className="container mx-auto px-4 py-4 max-w-3xl">
+          <div className="app-container py-4 max-w-3xl">
             <Link 
               href="/" 
               className="inline-flex items-center gap-2 text-sm text-muted-foreground hover:text-foreground transition-colors cursor-pointer"
@@ -30,7 +30,7 @@ export default function Terms() {
         </header>
 
         {/* Content */}
-        <main className="flex-1 container mx-auto px-4 py-8 sm:py-12 max-w-3xl">
+        <main className="flex-1 app-container py-8 sm:py-12 max-w-3xl">
           <article className="prose prose-neutral dark:prose-invert prose-headings:font-semibold prose-a:text-primary prose-a:no-underline hover:prose-a:underline max-w-none">
             <h1 className="text-3xl sm:text-4xl mb-2">Terms of Service</h1>
             <p className="text-muted-foreground text-sm mt-0 mb-8">

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -142,6 +142,13 @@
   }
 }
 
+/* Android WebView/PWA: stabilize bottom nav hit-testing */
+.android-webview .mobile-bottom-nav {
+  backdrop-filter: none;
+  -webkit-backdrop-filter: none;
+  transform: translateZ(0);
+}
+
 /* Smooth theme transition — only active during a theme switch */
 html.theme-transitioning,
 html.theme-transitioning *,

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -192,6 +192,10 @@ html.theme-transitioning *::after {
       min-height: 100dvh;
     }
   }
+
+  .app-container {
+    @apply w-full max-w-7xl mx-auto px-4 sm:px-6 md:px-8 lg:px-10 xl:px-12;
+  }
 }
 
 /* Admin Panel Typography - Uses CSS variables from next/font */

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -61,32 +61,32 @@
   .dark {
     color-scheme: dark;
 
-    --background: 220 13% 10%;
+    --background: 220 13% 7%;
     --foreground: 210 20% 98%;
 
-    --card: 220 13% 14%;
+    --card: 220 13% 11%;
     --card-foreground: 210 20% 98%;
 
-    --popover: 220 13% 16%;
+    --popover: 220 13% 12%;
     --popover-foreground: 210 20% 98%;
 
     --primary: 16 100% 50%;
     --primary-foreground: 0 0% 100%;
 
-    --secondary: 220 13% 20%;
+    --secondary: 220 13% 16%;
     --secondary-foreground: 210 20% 95%;
 
     --accent: 16 100% 50%;
     --accent-foreground: 0 0% 100%;
 
-    --muted: 220 13% 22%;
-    --muted-foreground: 215 15% 60%;
+    --muted: 220 13% 18%;
+    --muted-foreground: 215 15% 62%;
 
     --destructive: 0 72% 51%;
     --destructive-foreground: 0 0% 100%;
 
-    --border: 220 13% 25%;
-    --input: 220 13% 18%;
+    --border: 220 13% 22%;
+    --input: 220 13% 14%;
     --ring: 16 100% 50%;
 
     /* Admin Panel - Command Center Colors (Dark) */

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -165,6 +165,26 @@ html.theme-transitioning *::after {
   [draggable="true"]:active {
     cursor: grabbing;
   }
+
+  .safe-bottom {
+    padding-bottom: calc(5rem + env(safe-area-inset-bottom, 0px));
+  }
+
+  @media (min-width: 768px) {
+    .safe-bottom {
+      padding-bottom: 0;
+    }
+  }
+
+  .min-h-viewport {
+    min-height: 100svh;
+  }
+
+  @supports (height: 100dvh) {
+    .min-h-viewport {
+      min-height: 100dvh;
+    }
+  }
 }
 
 /* Admin Panel Typography - Uses CSS variables from next/font */

--- a/supabase/migrations/008_add_eligibility_to_subreddit_cache.sql
+++ b/supabase/migrations/008_add_eligibility_to_subreddit_cache.sql
@@ -1,0 +1,8 @@
+-- Add eligibility column to subreddit_cache table
+-- This stores user's eligibility status for subreddits (banned, approved, moderator, etc.)
+
+ALTER TABLE public.subreddit_cache
+ADD COLUMN IF NOT EXISTS eligibility jsonb DEFAULT NULL;
+
+-- Add comment for documentation
+COMMENT ON COLUMN public.subreddit_cache.eligibility IS 'Stores user eligibility data for the subreddit including userIsBanned, userIsContributor, userIsModerator, userIsSubscriber, submissionType, restrictPosting, and subredditType';

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -16,6 +16,10 @@ module.exports = {
           '0%, 100%': { transform: 'translateY(0px)' },
           '50%': { transform: 'translateY(-8px)' },
         },
+        subtleGlow: {
+          '0%, 100%': { boxShadow: '0 0 0 0 rgba(91, 33, 182, 0.35)' },
+          '50%': { boxShadow: '0 0 0 6px rgba(91, 33, 182, 0)' },
+        },
         fadeIn: {
           '0%': { opacity: '0' },
           '100%': { opacity: '1' },
@@ -23,6 +27,7 @@ module.exports = {
       },
       animation: {
         float: 'float 3s ease-in-out infinite',
+        'subtle-glow': 'subtleGlow 2.6s ease-in-out infinite',
         fadeIn: 'fadeIn 0.2s ease-out',
       },
       borderRadius: {

--- a/utils/reddit.ts
+++ b/utils/reddit.ts
@@ -461,17 +461,22 @@ export async function submitPost(client: AxiosInstance, params: SubmitParams): P
   form.set('sendreplies', 'true');
   
   // Handle different post types
-  // Handle different post types
   if (params.kind === 'self') {
     form.set('kind', 'self');
   } else if (params.kind === 'link') {
-    form.set('kind', 'link');
-    form.set('url', params.url || '');
-  } else if (params.kind === 'image' || params.kind === 'video') {
-    form.set('kind', 'image');
-    if (mediaAssetId) {
-      form.set('url', `https://reddit-uploaded-media.s3-accelerate.amazonaws.com/${mediaAssetId}`);
+    // Validate URL is provided for link posts
+    if (!params.url || params.url.trim() === '') {
+      throw new Error('URL is required for link posts');
     }
+    form.set('kind', 'link');
+    form.set('url', params.url);
+  } else if (params.kind === 'image' || params.kind === 'video') {
+    // For image/video posts, we need a media asset ID from file upload
+    if (!mediaAssetId) {
+      throw new Error('Media upload failed - no media asset ID available. Please try uploading the file again.');
+    }
+    form.set('kind', 'image');
+    form.set('url', `https://reddit-uploaded-media.s3-accelerate.amazonaws.com/${mediaAssetId}`);
   } else {
     // Fallback
     form.set('kind', 'self');


### PR DESCRIPTION
Summary
- deepen the dark theme palette, lowering background/card/popover/input tones and tightening border/muted variations to reduce glow on the Post All button and reinforce a black-leaning design language
- add a JSONB `eligibility` column to `subreddit_cache` with documentation so the cache can store user status flags in one place

Testing
- Not run (not requested)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Style**
  * Dark theme contrast tweaked for improved legibility; subtle new glow animation added.

* **New Features**
  * Subreddit eligibility tracking added.
  * Media reset support in the composer and posting queue.

* **UI/UX**
  * Footer verb gains a glitch/morph animation.
  * Better safe-area and viewport handling for mobile; Android WebView/PWA stability tweaks.
  * Drag-and-drop and touch interactions improved for settings/items.
  * Overlay stacking (z-index) adjusted to reduce layering conflicts.

* **Behavior**
  * Failed-posts view simplified; mobile queue auto-scroll/focus on posting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->