### PR TITLE
fix: resolve TypeScript type errors in eligibility checks

### DIFF
--- a/lib/preflightValidation.ts
+++ b/lib/preflightValidation.ts
@@ -665,11 +665,11 @@ export function getEligibilityForSubreddit(
     };
   }
 
-  // Update checks from eligibility data
-  checks.banned = eligibility.userIsBanned;
-  checks.approved = eligibility.userIsContributor;
-  checks.moderator = eligibility.userIsModerator;
-  checks.subscriber = eligibility.userIsSubscriber;
+  // Update checks from eligibility data (use nullish coalescing for optional fields)
+  checks.banned = eligibility.userIsBanned ?? false;
+  checks.approved = eligibility.userIsContributor ?? false;
+  checks.moderator = eligibility.userIsModerator ?? false;
+  checks.subscriber = eligibility.userIsSubscriber ?? false;
   checks.restrictedPosting = eligibility.restrictPosting;
   checks.subredditType = eligibility.subredditType;
 

--- a/pages/api/cache/subreddit/[name].ts
+++ b/pages/api/cache/subreddit/[name].ts
@@ -148,13 +148,12 @@ export default async function handler(
           getEnhancedSubredditInfo(client, subredditName).catch(() => null),
         ]);
 
-        // Parse requirements from enhanced info (wiki + sidebar + submit text)
+        // Parse requirements from enhanced info (sidebar + submit text)
         let parsedRequirements: ParsedRequirements | null = null;
         if (enhancedInfoResult) {
           const textToParse = [
             enhancedInfoResult.submitText,
             enhancedInfoResult.sidebarDescription,
-            enhancedInfoResult.wikiContent,
           ].filter(Boolean).join('\n\n');
           
           if (textToParse.trim()) {


### PR DESCRIPTION
- Add nullish coalescing defaults for optional boolean fields in eligibility checks
- Remove non-existent wikiContent property reference from cache endpoint

All typecheck errors now resolved.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced eligibility field handling with improved null-safety for optional values.
  * Streamlined subreddit requirement parsing by adjusting data sources used during caching operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->