### PR TITLE
fix: use daily cron schedule for Vercel Hobby plan

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,7 +2,7 @@
   "crons": [
     {
       "path": "/api/keep-alive",
-      "schedule": "0 */6 * * *"
+      "schedule": "0 0 * * *"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Changed keep-alive cron from `0 */6 * * *` (every 6 hours) to `0 0 * * *` (once daily at midnight UTC)
- Vercel Hobby plan only supports cron jobs that run at most once per day; the previous schedule triggered 4 times/day, causing deployment errors

## Test plan
- [ ] Verify Vercel deployment succeeds without cron schedule errors
- [ ] Confirm `/api/keep-alive` cron still appears in Vercel dashboard with the updated schedule

Made with [Cursor](https://cursor.com)