### PR TITLE
fix: add timeout, retry, and cancel for image uploads

### DIFF
--- a/hooks/useDirectUpload.ts
+++ b/hooks/useDirectUpload.ts
@@ -49,8 +49,20 @@ const isRetryableError = (error: unknown, response?: Response): boolean => {
   return false;
 };
 
-const delay = (ms: number): Promise<void> =>
-  new Promise((resolve) => setTimeout(resolve, ms));
+const delay = (ms: number, signal?: AbortSignal): Promise<void> =>
+  new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      reject(new DOMException('Aborted', 'AbortError'));
+      return;
+    }
+
+    const timeoutId = setTimeout(resolve, ms);
+
+    signal?.addEventListener('abort', () => {
+      clearTimeout(timeoutId);
+      reject(new DOMException('Aborted', 'AbortError'));
+    }, { once: true });
+  });
 
 export function useDirectUpload(): UseDirectUploadReturn {
   const [isUploading, setIsUploading] = useState(false);
@@ -196,7 +208,7 @@ export function useDirectUpload(): UseDirectUploadReturn {
                 attempt: attempt + 1,
                 fileIndex,
               });
-              await delay(RETRY_DELAYS_MS[attempt]);
+              await delay(RETRY_DELAYS_MS[attempt], signal);
             }
           }
 

--- a/hooks/useDirectUpload.ts
+++ b/hooks/useDirectUpload.ts
@@ -1,4 +1,5 @@
-import { useState, useCallback } from 'react';
+import { useState, useCallback, useRef } from 'react';
+import { addUIBreadcrumb } from '@/lib/clientErrorHandler';
 
 export interface UploadedFile {
   storagePath: string;
@@ -21,6 +22,7 @@ interface UseDirectUploadReturn {
     jobFolder: string,
     itemIndex?: number
   ) => Promise<UploadedFile[]>;
+  cancelUpload: () => void;
   isUploading: boolean;
   progress: UploadProgress | null;
   error: string | null;
@@ -33,15 +35,40 @@ interface UploadUrlResponse {
   storagePath: string;
 }
 
+const UPLOAD_TIMEOUT_MS = 60_000;
+const MAX_RETRIES = 2;
+const RETRY_DELAYS_MS = [1000, 2000];
+
+const isRetryableError = (error: unknown, response?: Response): boolean => {
+  if (error instanceof TypeError) {
+    return true;
+  }
+  if (response && response.status >= 500) {
+    return true;
+  }
+  return false;
+};
+
+const delay = (ms: number): Promise<void> =>
+  new Promise((resolve) => setTimeout(resolve, ms));
+
 export function useDirectUpload(): UseDirectUploadReturn {
   const [isUploading, setIsUploading] = useState(false);
   const [progress, setProgress] = useState<UploadProgress | null>(null);
   const [error, setError] = useState<string | null>(null);
+  const abortControllerRef = useRef<AbortController | null>(null);
 
   const reset = useCallback(() => {
     setIsUploading(false);
     setProgress(null);
     setError(null);
+  }, []);
+
+  const cancelUpload = useCallback(() => {
+    if (abortControllerRef.current) {
+      abortControllerRef.current.abort();
+      abortControllerRef.current = null;
+    }
   }, []);
 
   const uploadFiles = useCallback(
@@ -53,6 +80,9 @@ export function useDirectUpload(): UseDirectUploadReturn {
       if (files.length === 0) {
         return [];
       }
+
+      abortControllerRef.current = new AbortController();
+      const { signal } = abortControllerRef.current;
 
       setIsUploading(true);
       setError(null);
@@ -70,6 +100,13 @@ export function useDirectUpload(): UseDirectUploadReturn {
             fileName: file.name,
           });
 
+          addUIBreadcrumb('upload-url-start', {
+            fileName: file.name,
+            fileSize: file.size,
+            fileIndex,
+            itemIndex,
+          });
+
           const urlResponse = await fetch('/api/storage/upload-url', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -81,27 +118,96 @@ export function useDirectUpload(): UseDirectUploadReturn {
               itemIndex,
               fileIndex,
             }),
+            signal,
           });
 
           if (!urlResponse.ok) {
             const errorData = await urlResponse.json();
-            throw new Error(errorData.details || errorData.error || 'Failed to get upload URL');
+            throw new Error(
+              errorData.details || errorData.error || 'Failed to get upload URL'
+            );
           }
 
           const { uploadUrl, storagePath }: UploadUrlResponse =
             await urlResponse.json();
 
-          const uploadResponse = await fetch(uploadUrl, {
-            method: 'PUT',
-            headers: {
-              'Content-Type': file.type,
-            },
-            body: file,
+          addUIBreadcrumb('upload-url-success', {
+            storagePath,
+            fileIndex,
           });
 
-          if (!uploadResponse.ok) {
-            throw new Error(`Failed to upload ${file.name}: ${uploadResponse.statusText}`);
+          addUIBreadcrumb('storage-put-start', {
+            storagePath,
+            fileSize: file.size,
+            fileIndex,
+          });
+
+          let uploadResponse: Response | undefined;
+          let lastError: unknown;
+
+          for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+            try {
+              const timeoutSignal = AbortSignal.timeout(UPLOAD_TIMEOUT_MS);
+              const combinedSignal = AbortSignal.any([signal, timeoutSignal]);
+
+              uploadResponse = await fetch(uploadUrl, {
+                method: 'PUT',
+                headers: {
+                  'Content-Type': file.type,
+                },
+                body: file,
+                signal: combinedSignal,
+              });
+
+              if (uploadResponse.ok) {
+                break;
+              }
+
+              if (!isRetryableError(null, uploadResponse)) {
+                throw new Error(
+                  `Failed to upload ${file.name}: ${uploadResponse.statusText}`
+                );
+              }
+
+              lastError = new Error(
+                `Failed to upload ${file.name}: ${uploadResponse.statusText}`
+              );
+            } catch (err) {
+              if (err instanceof Error && err.name === 'AbortError') {
+                throw err;
+              }
+
+              if (err instanceof Error && err.name === 'TimeoutError') {
+                lastError = new Error(
+                  `Upload timed out for ${file.name}. Please check your connection and try again.`
+                );
+              } else {
+                lastError = err;
+              }
+
+              if (!isRetryableError(err)) {
+                throw lastError;
+              }
+            }
+
+            if (attempt < MAX_RETRIES) {
+              addUIBreadcrumb('storage-put-retry', {
+                storagePath,
+                attempt: attempt + 1,
+                fileIndex,
+              });
+              await delay(RETRY_DELAYS_MS[attempt]);
+            }
           }
+
+          if (!uploadResponse?.ok) {
+            throw lastError || new Error(`Failed to upload ${file.name}`);
+          }
+
+          addUIBreadcrumb('storage-put-success', {
+            storagePath,
+            fileIndex,
+          });
 
           uploadedFiles.push({
             storagePath,
@@ -121,11 +227,24 @@ export function useDirectUpload(): UseDirectUploadReturn {
 
         return uploadedFiles;
       } catch (err) {
+        if (err instanceof Error && err.name === 'AbortError') {
+          setError('Upload cancelled');
+          throw err;
+        }
+
         const errorMessage = err instanceof Error ? err.message : 'Upload failed';
         setError(errorMessage);
+
+        addUIBreadcrumb('upload-failed', {
+          error: errorMessage,
+          uploadedCount: uploadedFiles.length,
+          totalFiles: files.length,
+        });
+
         throw err;
       } finally {
         setIsUploading(false);
+        abortControllerRef.current = null;
       }
     },
     []
@@ -133,6 +252,7 @@ export function useDirectUpload(): UseDirectUploadReturn {
 
   return {
     uploadFiles,
+    cancelUpload,
     isUploading,
     progress,
     error,

--- a/hooks/useQueueJob.ts
+++ b/hooks/useQueueJob.ts
@@ -170,6 +170,7 @@ export function useQueueJob(): UseQueueJobReturn {
   const channelRef = useRef<RealtimeChannel | null>(null);
   const pollingRef = useRef<NodeJS.Timeout | null>(null);
   const abortControllerRef = useRef<AbortController | null>(null);
+  const submitAbortControllerRef = useRef<AbortController | null>(null);
   const isProcessingRef = useRef(false);
 
   // Sync upload state
@@ -419,6 +420,10 @@ export function useQueueJob(): UseQueueJobReturn {
   ): Promise<string | null> => {
     const { showToast = true, toastTitle = 'Submission Failed' } = options;
 
+    // Create abort controller for the submit request
+    submitAbortControllerRef.current = new AbortController();
+    const submitSignal = submitAbortControllerRef.current.signal;
+
     setState(prev => ({
       ...prev,
       isSubmitting: true,
@@ -477,11 +482,17 @@ export function useQueueJob(): UseQueueJobReturn {
         })),
       };
 
+      // Check if aborted before submitting
+      if (submitSignal.aborted) {
+        throw new DOMException('Aborted', 'AbortError');
+      }
+
       // Submit to API (lightweight JSON, no file binaries)
       const response = await fetch('/api/queue/submit', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(requestBody),
+        signal: submitSignal,
       });
 
       const data = await response.json();
@@ -514,6 +525,19 @@ export function useQueueJob(): UseQueueJobReturn {
 
       return jobId;
     } catch (error) {
+      // Handle abort errors silently (user cancelled)
+      if (error instanceof Error && error.name === 'AbortError') {
+        setState(prev => ({
+          ...prev,
+          isSubmitting: false,
+          isUploading: false,
+          uploadProgress: null,
+          error: 'Submission cancelled',
+          endedAtMs: prev.endedAtMs ?? Date.now(),
+        }));
+        return null;
+      }
+
       const errorMessage = captureClientError(error, 'useQueueJob.submit', {
         showToast,
         toastTitle,
@@ -528,6 +552,8 @@ export function useQueueJob(): UseQueueJobReturn {
         endedAtMs: prev.endedAtMs ?? Date.now(),
       }));
       return null;
+    } finally {
+      submitAbortControllerRef.current = null;
     }
   }, [subscribeToJob, startPolling, uploadFiles]);
 
@@ -584,15 +610,21 @@ export function useQueueJob(): UseQueueJobReturn {
   const cancel = useCallback(async (): Promise<boolean> => {
     const { jobId, isSubmitting } = state;
 
-    // Cancel during upload phase (no jobId yet)
+    // Cancel during upload/submit phase (no jobId yet)
     if (!jobId && isSubmitting) {
+      // Abort any ongoing upload
       cancelUpload();
+      // Abort any ongoing submit request
+      if (submitAbortControllerRef.current) {
+        submitAbortControllerRef.current.abort();
+        submitAbortControllerRef.current = null;
+      }
       setState(prev => ({
         ...prev,
         isSubmitting: false,
         isUploading: false,
         uploadProgress: null,
-        error: 'Upload cancelled',
+        error: 'Submission cancelled',
         endedAtMs: Date.now(),
       }));
       return true;

--- a/hooks/useQueueJob.ts
+++ b/hooks/useQueueJob.ts
@@ -163,7 +163,7 @@ const mergeResultsByIndex = (
 
 export function useQueueJob(): UseQueueJobReturn {
   const [state, setState] = useState<QueueJobState>(initialState);
-  const { uploadFiles, isUploading, progress: uploadProgress, error: uploadError } = useDirectUpload();
+  const { uploadFiles, cancelUpload, isUploading, progress: uploadProgress } = useDirectUpload();
   
   // Refs for cleanup
   const supabaseClientRef = useRef<SupabaseClient | null>(null);
@@ -582,7 +582,22 @@ export function useQueueJob(): UseQueueJobReturn {
   // ============================================================================
 
   const cancel = useCallback(async (): Promise<boolean> => {
-    const { jobId } = state;
+    const { jobId, isSubmitting } = state;
+
+    // Cancel during upload phase (no jobId yet)
+    if (!jobId && isSubmitting) {
+      cancelUpload();
+      setState(prev => ({
+        ...prev,
+        isSubmitting: false,
+        isUploading: false,
+        uploadProgress: null,
+        error: 'Upload cancelled',
+        endedAtMs: Date.now(),
+      }));
+      return true;
+    }
+
     if (!jobId) return false;
 
     try {
@@ -619,7 +634,7 @@ export function useQueueJob(): UseQueueJobReturn {
       }));
       return false;
     }
-  }, [state.jobId, stopPolling]);
+  }, [state.jobId, state.isSubmitting, stopPolling, cancelUpload]);
 
   // ============================================================================
   // Resume Job (for page refresh)


### PR DESCRIPTION
## Summary

- Add 60-second timeout per file upload to prevent indefinite hangs when uploading to Supabase Storage
- Add retry logic (2 retries with 1s/2s exponential backoff) for transient network/5xx failures
- Wire Stop button to cancel uploads during pre-jobId phase (was previously non-functional)
- Add Sentry breadcrumbs at each upload step for debugging visibility

## Problem

Users were getting stuck at "Preparing..." with no errors in Vercel logs or Sentry. The PUT request to Supabase Storage goes directly from browser to Supabase CDN (never touches Vercel), so hangs were invisible. The Stop button also didn't work during uploads because there was no jobId yet.

## Test plan

- [ ] Upload 2 images (~500KB each) and verify posting completes
- [ ] Simulate slow network and verify timeout triggers after 60s
- [ ] Click Stop during upload phase and verify it cancels immediately
- [ ] Check Sentry breadcrumbs show upload-url-start, upload-url-success, storage-put-start, storage-put-success


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Cancel active uploads and cancel in-progress submissions.
  * Per-file retry with configurable backoff and overall upload timeout.

* **Improvements**
  * More detailed progress and error breadcrumbs during upload lifecycle.
  * Distinguishes user cancellations from timeouts and transient errors; preserves clearer upload/submission state.
  * Improved reliability and automatic recovery for interrupted transfers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->